### PR TITLE
Faster data builder and parallelization

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "YOUR_PATH = \"/Users/ducela/Documents/Raking/ihmeuw-msca/raking/\""
+    "YOUR_PATH = \"\""
    ]
   },
   {
@@ -860,7 +860,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.12"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/docs/getting_started_exp.ipynb
+++ b/docs/getting_started_exp.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "YOUR_PATH = \"/ihme/homes/ducela/ihmeuw-msca/raking/\""
+    "YOUR_PATH = \"\""
    ]
   },
   {

--- a/docs/getting_started_exp.ipynb
+++ b/docs/getting_started_exp.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "YOUR_PATH = \"/Users/ducela/Documents/Raking/ihmeuw-msca/raking/\""
+    "YOUR_PATH = \"/ihme/homes/ducela/ihmeuw-msca/raking/\""
    ]
   },
   {
@@ -120,7 +120,7 @@
        "  message: CONVERGENCE: RELATIVE REDUCTION OF F <= FACTR*EPSMCH\n",
        "  success: True\n",
        "   status: 0\n",
-       "      fun: 6.9408010589989875\n",
+       "      fun: 6.940801058998988\n",
        "        x: [-9.961e-04]\n",
        "      nit: 3\n",
        "      jac: [ 1.084e-11]\n",
@@ -363,7 +363,7 @@
        "  message: CONVERGENCE: RELATIVE REDUCTION OF F <= FACTR*EPSMCH\n",
        "  success: True\n",
        "   status: 0\n",
-       "      fun: 150.7699855612442\n",
+       "      fun: 150.76998556124423\n",
        "        x: [-4.606e-02 -9.952e-03 ...  2.920e-02  3.608e-02]\n",
        "      nit: 26\n",
        "      jac: [-7.671e-07  3.663e-06 ...  2.683e-06  1.457e-05]\n",
@@ -496,12 +496,12 @@
        "  message: CONVERGENCE: RELATIVE REDUCTION OF F <= FACTR*EPSMCH\n",
        "  success: True\n",
        "   status: 0\n",
-       "      fun: 159.6193588261129\n",
-       "        x: [ 5.457e-02  1.679e-02 ... -4.723e-01 -5.950e-01]\n",
-       "      nit: 125\n",
-       "      jac: [-5.167e-05 -2.049e-05 ... -1.178e-05  1.735e-06]\n",
-       "     nfev: 134\n",
-       "     njev: 134\n",
+       "      fun: 159.61935884972746\n",
+       "        x: [ 5.458e-02  1.679e-02 ... -4.723e-01 -5.950e-01]\n",
+       "      nit: 124\n",
+       "      jac: [ 1.665e-05 -3.230e-05 ... -1.418e-05  8.437e-06]\n",
+       "     nfev: 133\n",
+       "     njev: 133\n",
        " hess_inv: <30x30 LbfgsInvHessProduct with dtype=float64>"
       ]
      },
@@ -646,10 +646,10 @@
        "  message: CONVERGENCE: RELATIVE REDUCTION OF F <= FACTR*EPSMCH\n",
        "  success: True\n",
        "   status: 0\n",
-       "      fun: 4.6554862448094285\n",
+       "      fun: 4.655486244808755\n",
        "        x: [ 1.410e-02  3.647e-02 ... -4.615e-01 -6.325e-01]\n",
        "      nit: 133\n",
-       "      jac: [ 5.744e-07  5.623e-07 ... -2.453e-06 -1.261e-06]\n",
+       "      jac: [ 5.624e-07  5.523e-07 ... -2.367e-06 -1.254e-06]\n",
        "     nfev: 140\n",
        "     njev: 140\n",
        " hess_inv: <27x27 LbfgsInvHessProduct with dtype=float64>"
@@ -729,9 +729,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "raking_GBD",
    "language": "python",
-   "name": "python3"
+   "name": "raking_gbd"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/user_guide/using_experimental.rst
+++ b/docs/user_guide/using_experimental.rst
@@ -10,16 +10,389 @@ You only need a single pandas data frame containing the information on both the 
 
 If the row corresponds to an observation present in the data frame, the weight must be strictly positive. If the row corresponds to a missing observation for which a raked value must be computed, the value must be set to np.nan and the weight must be set to 0. If the row corresponds to a constraint (either an observation with no uncertainty that must not move though the raking, or a known margin that must also stay constant), the weight must be set to np.inf. The most certain observations must be assigned bigger weights than the most uncertain observations.
 
+1D raking
+^^^^^^^^^
+
+The input data frame looks like this:
+
+========  ======  =======
+  value    var1   weights
+========  ======  =======
+2.647452     0      1.0
+2.216220     1      1.0
+2.077133     2      1.0
+6.947722    -1      inf
+
+2D raking
+^^^^^^^^^
+
+The input data frame looks like this:
+
+=========  ======  ======  =======
+  value     var1    var2   weights
+=========  ======  ======  =======
+ 2.563735     0      0       1.0
+ 2.858330     1      0       1.0
+ 2.784224     2      0       1.0
+ 2.310950     0      1       1.0
+ 2.710887     1      1       1.0
+ 1.989885     2      1       1.0
+ 2.177620     0      2       1.0
+ 2.662977     1      2       1.0
+ 2.892555     2      2       1.0
+ 2.106875     0      3       1.0
+ 2.553026     1      3       1.0
+ 1.959236     2      3       1.0
+ 2.721098     0      4       1.0
+ 2.889300     1      4       1.0
+ 2.751675     2      4       1.0
+ 8.365571    -1      0       inf
+ 6.879161    -1      1       inf
+ 7.627874    -1      2       inf
+ 6.593738    -1      3       inf
+ 8.477998    -1      4       inf
+11.777520     0     -1       inf
+13.727585     1     -1       inf
+12.439237     2     -1       inf
+
+3D raking
+^^^^^^^^^
+
+The input data frame looks like this:
+
+=========  ======  ======  ======  =======
+  value     var1    var2    var3   weights
+=========  ======  ======  ======  =======
+ 2.593318     0       0       0      1.0
+ 1.911339     1       0       0      1.0
+ 2.745467     2       0       0      1.0
+ 2.863165     0       1       0      1.0
+ 2.416575     1       1       0      1.0
+ 2.864417     2       1       0      1.0
+ 2.974201     0       2       0      1.0
+ 2.820483     1       2       0      1.0
+ 2.850434     2       2       0      1.0
+ 1.955305     0       3       0      1.0
+ 2.315445     1       3       0      1.0
+ 2.218648     2       3       0      1.0
+ 2.370183     0       0       1      1.0
+ 2.062493     1       0       1      1.0
+ 2.504071     2       0       1      1.0
+ 2.474593     0       1       1      1.0
+ 2.931057     1       1       1      1.0
+ 2.320663     2       1       1      1.0
+ 2.007644     0       2       1      1.0
+ 2.589161     1       2       1      1.0
+ 2.258221     2       2       1      1.0
+ 2.799860     0       3       1      1.0
+ 2.448079     1       3       1      1.0
+ 2.341225     2       3       1      1.0
+ 1.913206     0       0       2      1.0
+ 2.733666     1       0       2      1.0
+ 2.652417     2       0       2      1.0
+ 2.858952     0       1       2      1.0
+ 2.905375     1       1       2      1.0
+ 2.792098     2       1       2      1.0
+ 2.828666     0       2       2      1.0
+ 2.292537     1       2       2      1.0
+ 2.833206     2       2       2      1.0
+ 2.467913     0       3       2      1.0
+ 2.914466     1       3       2      1.0
+ 2.899470     2       3       2      1.0
+ 2.032629     0       0       3      1.0
+ 2.588637     1       0       3      1.0
+ 2.203789     2       0       3      1.0
+ 2.403473     0       1       3      1.0
+ 2.735810     1       1       3      1.0
+ 2.182987     2       1       3      1.0
+ 2.017156     0       2       3      1.0
+ 2.614052     1       2       3      1.0
+ 2.145872     2       2       3      1.0
+ 2.171672     0       3       3      1.0
+ 2.862737     1       3       3      1.0
+ 2.292744     2       3       3      1.0
+ 2.588256     0       0       4      1.0
+ 2.654022     1       0       4      1.0
+ 2.333455     2       0       4      1.0
+ 2.946000     0       1       4      1.0
+ 2.642889     1       1       4      1.0
+ 2.852856     2       1       4      1.0
+ 2.799073     0       2       4      1.0
+ 2.449517     1       2       4      1.0
+ 2.478215     2       2       4      1.0
+ 2.495297     0       3       4      1.0
+ 2.442168     1       3       4      1.0
+ 2.168508     2       3       4      1.0
+ 7.236811    -1       0       0      inf
+ 8.186707    -1       1       0      inf
+ 8.291399    -1       2       0      inf
+ 6.636177    -1       3       0      inf
+ 6.715939    -1       0       1      inf
+ 7.831003    -1       1       1      inf
+ 6.631029    -1       2       1      inf
+ 7.799354    -1       3       1      inf
+ 7.305898    -1       0       2      inf
+ 8.333519    -1       1       2      inf
+ 7.868985    -1       2       2      inf
+ 8.227273    -1       3       2      inf
+ 7.001628    -1       0       3      inf
+ 7.313182    -1       1       3      inf
+ 6.813642    -1       2       3      inf
+ 7.464398    -1       3       3      inf
+ 7.820274    -1       0       4      inf
+ 8.418176    -1       1       4      inf
+ 7.591127    -1       2       4      inf
+ 6.832504    -1       3       4      inf
+10.541226     0      -1       0      inf
+ 9.410686     1      -1       0      inf
+10.399182     2      -1       0      inf
+ 9.742340     0      -1       1      inf
+ 9.996250     1      -1       1      inf
+ 9.238736     2      -1       1      inf
+10.169336     0      -1       2      inf
+10.676044     1      -1       2      inf
+10.890296     2      -1       2      inf
+ 8.893450     0      -1       3      inf
+10.988263     1      -1       3      inf
+ 8.711137     2      -1       3      inf
+10.900685     0      -1       4      inf
+10.148994     1      -1       4      inf
+ 9.612402     2      -1       4      inf
+11.777520     0       0      -1      inf
+12.085802     1       0      -1      inf
+12.217229     2       0      -1      inf
+13.727585     0       1      -1      inf
+13.697724     1       1      -1      inf
+12.657279     2       1      -1      inf
+12.439237     0       2      -1      inf
+12.459307     1       2      -1      inf
+12.297637     2       2      -1      inf
+12.302695     0       3      -1      inf
+12.977404     1       3      -1      inf
+11.679607     2       3      -1      inf
+
+USHD raking (level 1 to all-cause)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The input data frame looks like this:
+
+=========  =====  ====  ======  =======
+  value    cause  race  county  weights
+=========  =====  ====  ======  =======
+ 7.619521   -1     -1    301      1.0
+ 4.612771    1     -1    301      1.0
+ 0.527299    2     -1    301      1.0
+ 2.413023    3     -1    301      1.0
+ 0.758506   -1      2    301      1.0
+ 0.512337    1      2    301      1.0
+ 0.043705    2      2    301      1.0
+ 0.227653    3      2    301      1.0
+ 3.878259   -1      4    301      1.0
+ 2.580850    1      4    301      1.0
+ 0.251599    2      4    301      1.0
+ 1.182016    3      4    301      1.0
+ 3.196077   -1      5    301      1.0
+ 1.691201    1      5    301      1.0
+ 0.254102    2      5    301      1.0
+ 1.171041    3      5    301      1.0
+ 0.007639   -1      6    301      1.0
+ 0.003628    1      6    301      1.0
+ 0.000683    2      6    301      1.0
+ 0.003480    3      6    301      1.0
+ 0.135695   -1      7    301      1.0
+ 0.103740    1      7    301      1.0
+ 0.005382    2      7    301      1.0
+ 0.041140    3      7    301      1.0
+24.251880   -1     -1    302      1.0
+18.114488    1     -1    302      1.0
+ 1.458384    2     -1    302      1.0
+ 5.411759    3     -1    302      1.0
+ 3.217496   -1      2    302      1.0
+ 1.944748    1      2    302      1.0
+ 0.155655    2      2    302      1.0
+ 0.891519    3      2    302      1.0
+13.427143   -1      4    302      1.0
+ 9.477908    1      4    302      1.0
+ 1.032675    2      4    302      1.0
+ 2.520661    3      4    302      1.0
+ 6.894521   -1      5    302      1.0
+ 5.039603    1      5    302      1.0
+ 0.369887    2      5    302      1.0
+ 2.076813    3      5    302      1.0
+ 0.025593   -1      6    302      1.0
+ 0.016065    1      6    302      1.0
+ 0.002706    2      6    302      1.0
+ 0.012746    3      6    302      1.0
+ 1.708524   -1      7    302      1.0
+ 1.207481    1      7    302      1.0
+ 0.073614    2      7    302      1.0
+ 0.440330    3      7    302      1.0
+ 7.240533   -1     -1    303      1.0
+ 4.236110    1     -1    303      1.0
+ 0.598651    2     -1    303      1.0
+ 2.328931    3     -1    303      1.0
+ 1.167699   -1      2    303      1.0
+ 0.749765    1      2    303      1.0
+ 0.085868    2      2    303      1.0
+ 0.394253    3      2    303      1.0
+ 3.432895   -1      4    303      1.0
+ 1.975344    1      4    303      1.0
+ 0.273134    2      4    303      1.0
+ 0.906347    3      4    303      1.0
+ 2.899930   -1      5    303      1.0
+ 1.766393    1      5    303      1.0
+ 0.247110    2      5    303      1.0
+ 1.106343    3      5    303      1.0
+ 0.005331   -1      6    303      1.0
+ 0.002848    1      6    303      1.0
+ 0.000520    2      6    303      1.0
+ 0.002428    3      6    303      1.0
+ 0.131920   -1      7    303      1.0
+ 0.076260    1      7    303      1.0
+ 0.004744    2      7    303      1.0
+ 0.037682    3      7    303      1.0
+43.886284   -1     -1     -1      inf
+27.823886    1     -1     -1      inf
+ 3.107935    2     -1     -1      inf
+12.954463    3     -1     -1      inf
+
+USHD raking (level 2 to level 1 parent cause)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The input data frame looks like this:
+
+=========  =====  ====  ======  =======
+  value    cause  race  county  weights
+=========  =====  ====  ======  =======
+ 0.118175    1     -1    301      1.0
+ 0.293406    2     -1    301      1.0
+ 0.033900    3     -1    301      1.0
+ 0.010369    1      2    301      1.0
+ 0.027488    2      2    301      1.0
+ 0.003967    3      2    301      1.0
+ 0.049080    1      4    301      1.0
+ 0.209313    2      4    301      1.0
+ 0.015435    3      4    301      1.0
+ 0.053521    1      5    301      1.0
+ 0.135591    2      5    301      1.0
+ 0.017261    3      5    301      1.0
+ 0.000157    1      6    301      1.0
+ 0.000570    2      6    301      1.0
+ 0.000085    3      6    301      1.0
+ 0.001131    1      7    301      1.0
+ 0.003324    2      7    301      1.0
+ 0.000431    3      7    301      1.0
+ 0.376631    1     -1    302      1.0
+ 0.820883    2     -1    302      1.0
+ 0.073213    3     -1    302      1.0
+ 0.037681    1      2    302      1.0
+ 0.097146    2      2    302      1.0
+ 0.010592    3      2    302      1.0
+ 0.238464    1      4    302      1.0
+ 0.634665    2      4    302      1.0
+ 0.043052    3      4    302      1.0
+ 0.087516    1      5    302      1.0
+ 0.263410    2      5    302      1.0
+ 0.021672    3      5    302      1.0
+ 0.000758    1      6    302      1.0
+ 0.002557    2      6    302      1.0
+ 0.000289    3      6    302      1.0
+ 0.015757    1      7    302      1.0
+ 0.045956    2      7    302      1.0
+ 0.006432    3      7    302      1.0
+ 0.103712    1     -1    303      1.0
+ 0.418953    2     -1    303      1.0
+ 0.041973    3     -1    303      1.0
+ 0.013333    1      2    303      1.0
+ 0.045058    2      2    303      1.0
+ 0.011201    3      2    303      1.0
+ 0.035000    1      4    303      1.0
+ 0.224885    2      4    303      1.0
+ 0.016696    3      4    303      1.0
+ 0.046943    1      5    303      1.0
+ 0.175575    2      5    303      1.0
+ 0.016886    3      5    303      1.0
+ 0.000111    1      6    303      1.0
+ 0.000377    2      6    303      1.0
+ 0.000065    3      6    303      1.0
+ 0.000934    1      7    303      1.0
+ 0.002890    2      7    303      1.0
+ 0.000409    3      7    303      1.0
+ 0.604437    1     -1     -1      inf
+ 2.273448    2     -1     -1      inf
+ 0.230049    3     -1     -1      inf
+ 0.624089   -1     -1    301      inf
+ 1.784524   -1     -1    302      inf
+ 0.699322   -1     -1    303      inf
+ 0.048717   -1      2    301      inf
+ 0.280005   -1      4    301      inf
+ 0.288797   -1      5    301      inf
+ 0.000756   -1      6    301      inf
+ 0.005816   -1      7    301      inf
+ 0.174820   -1      2    302      inf
+ 1.142346   -1      4    302      inf
+ 0.385038   -1      5    302      inf
+ 0.002607   -1      6    302      inf
+ 0.079712   -1      7    302      inf
+ 0.095836   -1      2    303      inf
+ 0.325318   -1      4    303      inf
+ 0.271897   -1      5    303      inf
+ 0.000565   -1      6    303      inf
+ 0.005705   -1      7    303      inf
+
 Using the data builder
 ----------------------
 
-You must first specify how the data are encoded in the pandas data frame. In dim_specs, you need to specify which value corresponds to the aggregate (e.g. if raking over cause, which value in the ``cause`` column corresponds to all cause). You also need to specify the name of the column that contain the values and the name of the column that contains the weights. For example, if you rake by cause and location, and all cause is encoded by math:`-1` and all location is encoded by math:`-1`:
+You must first specify how the data are encoded in the pandas data frame. In dim_specs, you need to specify which value corresponds to the aggregate (e.g. if raking over cause, which value in the ``cause`` column corresponds to all cause). You also need to specify the name of the column that contain the values and the name of the column that contains the weights. 
+
+Data builder for 1D raking
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
     data_builder = DataBuilder(
-        dim_specs={'cause': -1, 'location': -1},
+        dim_specs={'var1': -1},
         value='value',
         weights='weights'
+    )
+
+Data builder for 2D raking
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+    data_builder = DataBuilder(
+        dim_specs={'var1': -1, 'var2': -1},
+        value='value',
+        weights='weights'
+    )
+
+Data builder for 3D raking
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+    data_builder = DataBuilder(
+        dim_specs={"var1": -1, "var2": -1, "var3": -1},
+        value='value',
+        weights='weights'
+    )
+
+Data builder for USHD raking (level 1 to all-cause)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+    data_builder = DataBuilder(
+        dim_specs={"cause": -1, "race": -1, "county": -1},
+        value="value",
+        weights="weights",
+    )
+
+Data builder for USHD raking (level 2 to level 1 parent cause)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+    data_builder = DataBuilder(
+        dim_specs={"cause": -1, "race": -1, "county": -1},
+        value="value",
+        weights="weights",
     )
 
 You then need to build the data using your input pandas data frame:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "raking"
 version = "0.2.0"
 description = "Python package template"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = "=3.11"
 license = { text = "BSD-2-Clause" }
 authors = [
     { name = "IHME Math Sciences", email = "ihme.math.sciences@gmail.com" },
@@ -18,7 +18,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 dependencies = [
-    "numpy",
+    "numpy=1.26",
     "pandas",
     "pydantic>=2.10.6",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "raking"
 version = "0.2.0"
 description = "Python package template"
 readme = "README.md"
-requires-python = "==3.11"
+requires-python = ">=3.10"
 license = { text = "BSD-2-Clause" }
 authors = [
     { name = "IHME Math Sciences", email = "ihme.math.sciences@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "raking"
 version = "0.2.0"
 description = "Python package template"
 readme = "README.md"
-requires-python = "=3.11"
+requires-python = "==3.11"
 license = { text = "BSD-2-Clause" }
 authors = [
     { name = "IHME Math Sciences", email = "ihme.math.sciences@gmail.com" },
@@ -18,7 +18,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 dependencies = [
-    "numpy=1.26",
+    "numpy==1.26",
     "pandas",
     "pydantic>=2.10.6",
     "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ classifiers = [
     "Natural Language :: English",
 ]
 dependencies = [
-    "numpy==1.26",
-    "pandas",
+    "numpy",
+    "pandas<3",
     "pydantic>=2.10.6",
     "scipy",
 ]

--- a/src/raking/compute_constraints.py
+++ b/src/raking/compute_constraints.py
@@ -4,7 +4,8 @@ import numpy as np
 import scipy.sparse as sps
 
 
-def constraints_1D(s: float, I: int) -> tuple[sps.csr_matrix, np.ndarray]:
+#def constraints_1D(s: float, I: int) -> tuple[sps.csr_matrix, np.ndarray]:
+def constraints_1D(s: float, I: int) -> tuple[np.ndarray, np.ndarray]:
     """Compute the constraints matrix A and the margins vector s in 1D.
 
     This will define the raking optimization problem:
@@ -36,7 +37,9 @@ def constraints_1D(s: float, I: int) -> tuple[sps.csr_matrix, np.ndarray]:
         "The number of possible values taken by the categorical variable must be higher than 1."
     )
 
-    A = sps.csr_matrix(np.ones((1, I)))
+#    A = sps.csr_matrix(np.ones((1, I)))
+#    s = np.array([s])
+    A = np.ones((1, I))
     s = np.array([s])
     return (A, s)
 
@@ -48,7 +51,8 @@ def constraints_2D(
     J: int,
     rtol: float = 1e-05,
     atol: float = 1e-08,
-) -> tuple[sps.csr_matrix, np.ndarray]:
+#) -> tuple[sps.csr_matrix, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     """Compute the constraints matrix A and the margins vector s in 2D.
 
     This will define the raking optimization problem:
@@ -116,13 +120,20 @@ def constraints_2D(
         "The sum of the row margins must be equal to the sum of the column margins."
     )
 
-    identity_I = sps.csr_matrix(np.eye(I, dtype=int))
-    identity_J = sps.csr_matrix(np.eye(J, dtype=int))
-    one_I = sps.csr_matrix(np.ones((I, 1), dtype=int))
-    one_J = sps.csr_matrix(np.ones((J, 1), dtype=int))
-    A1 = sps.kron(identity_J, one_I.transpose())
-    A2 = sps.kron(one_J.transpose(), identity_I[0 : (I - 1), :])
-    A = sps.vstack([A1, A2])
+#    identity_I = sps.csr_matrix(np.eye(I, dtype=int))
+#    identity_J = sps.csr_matrix(np.eye(J, dtype=int))
+#    one_I = sps.csr_matrix(np.ones((I, 1), dtype=int))
+#    one_J = sps.csr_matrix(np.ones((J, 1), dtype=int))
+#    A1 = sps.kron(identity_J, one_I.transpose())
+#    A2 = sps.kron(one_J.transpose(), identity_I[0 : (I - 1), :])
+#    A = sps.vstack([A1, A2])
+#    s = np.concatenate([s1, s2[0 : (I - 1)]])
+    A = np.zeros((J + I - 1, I * J))
+    for j in range(0, J):
+        for i in range(0, I - 1):
+            A[J + i, j * I + i] = 1
+            A[j, j * I + i] = 1
+        A[j, j * I + I - 1] = 1
     s = np.concatenate([s1, s2[0 : (I - 1)]])
     return (A, s)
 
@@ -250,22 +261,33 @@ def constraints_3D(
         "The sums of the targets for dimension 1 and 3 must be equal."
     )
 
-    identity_I = sps.csr_matrix(np.eye(I, dtype=int))
-    identity_J = sps.csr_matrix(np.eye(J, dtype=int))
-    identity_K = sps.csr_matrix(np.eye(K, dtype=int))
-    identity_JK = sps.csr_matrix(np.eye(J * K, dtype=int))
-    one_I = sps.csr_matrix(np.ones((I, 1), dtype=int))
-    one_J = sps.csr_matrix(np.ones((J, 1), dtype=int))
-    one_K = sps.csr_matrix(np.ones((K, 1), dtype=int))
-    A = []
-    A.append(sps.kron(
-        identity_K, sps.kron(identity_J[0 : (J - 1), :], one_I.transpose())
-    ))
-    A.append(sps.kron(identity_JK[J * K - 1, :], one_I.transpose()))
-    for i in range(0, I):
-        A.append(sps.kron(sps.kron(identity_K[0:(K - 1),:], one_J.transpose()), identity_I[i,:]))
-    A.append(sps.kron(one_K.transpose(), sps.kron(identity_J, identity_I[0:(I - 1),:])))
-    A = sps.vstack(A)
+#    identity_I = sps.csr_matrix(np.eye(I, dtype=int))
+#    identity_J = sps.csr_matrix(np.eye(J, dtype=int))
+#    identity_K = sps.csr_matrix(np.eye(K, dtype=int))
+#    identity_JK = sps.csr_matrix(np.eye(J * K, dtype=int))
+#    one_I = sps.csr_matrix(np.ones((I, 1), dtype=int))
+#    one_J = sps.csr_matrix(np.ones((J, 1), dtype=int))
+#    one_K = sps.csr_matrix(np.ones((K, 1), dtype=int))
+#    A = []
+#    A.append(
+#        sps.kron(
+#            identity_K, sps.kron(identity_J[0 : (J - 1), :], one_I.transpose())
+#        )
+#    )
+#    A.append(sps.kron(identity_JK[J * K - 1, :], one_I.transpose()))
+#    for i in range(0, I):
+#        A.append(
+#            sps.kron(
+#                sps.kron(identity_K[0 : (K - 1), :], one_J.transpose()),
+#                identity_I[i, :],
+#            )
+#        )
+#    A.append(
+#        sps.kron(
+#            one_K.transpose(), sps.kron(identity_J, identity_I[0 : (I - 1), :])
+#        )
+#    )
+#    A = sps.vstack(A)
 
     A = np.zeros((I * J + I * K + J * K - I - J - K + 1, I * J * K))
     s = np.zeros(I * J + I * K + J * K - I - J - K + 1)
@@ -523,12 +545,12 @@ def constraints_USHD_lower(
         "The shape of the margins vector for the all causes deaths must be equal to the number of races multiplied by the number of counties."
     )
 
-#    assert np.allclose(np.sum(s_cause), np.sum(s_county), rtol, atol), (
-#        "The sum of the number of deaths per cause must be equal to the sum of the number of deaths per county."
-#    )
-#    assert np.allclose(np.sum(s_all_causes, axis=0), s_county, rtol, atol), (
-#        "For each county, the all-races number of deaths must be equal to the sum of the number of deaths per race."
-#    )
+    #    assert np.allclose(np.sum(s_cause), np.sum(s_county), rtol, atol), (
+    #        "The sum of the number of deaths per cause must be equal to the sum of the number of deaths per county."
+    #    )
+    #    assert np.allclose(np.sum(s_all_causes, axis=0), s_county, rtol, atol), (
+    #        "For each county, the all-races number of deaths must be equal to the sum of the number of deaths per race."
+    #    )
 
     A = np.zeros((I + K + I * K + J * K - K - 1, I * (J + 1) * K))
     s = np.zeros(I + K + I * K + J * K - K - 1)

--- a/src/raking/compute_constraints.py
+++ b/src/raking/compute_constraints.py
@@ -33,14 +33,27 @@ def constraints_1D(s: float, I: int) -> tuple[np.ndarray, np.ndarray]:
     assert isinstance(I, int), (
         "The number of possible values taken by the categorical variable must be an integer."
     )
-    assert I > 1, (
-        "The number of possible values taken by the categorical variable must be higher than 1."
-    )
+#    assert I > 1, (
+#        "The number of possible values taken by the categorical variable must be higher than 1."
+#    )
 
 #    A = sps.csr_matrix(np.ones((1, I)))
 #    s = np.array([s])
     A = np.ones((1, I))
     s = np.array([s])
+    return (A, s)
+
+
+def constraints_1D_parallel(
+    s: np.ndarray,
+    I: int,
+    N: int
+) -> tuple[sps.csr_matrix, np.ndarray]:
+    (A_loc, s_loc) = constraints_1D(s[0], I)
+    # Transform to sparse
+    A_loc = sps.csr_matrix(A_loc)
+    I_N = sps.csr_matrix(np.eye(N, dtype=int))
+    A = sps.kron(I_N, A_loc)
     return (A, s)
 
 

--- a/src/raking/compute_constraints.py
+++ b/src/raking/compute_constraints.py
@@ -3,7 +3,8 @@
 import numpy as np
 import scipy.sparse as sps
 
-def constraints_1D(s: float, I: int) -> tuple[np.ndarray, np.ndarray]:
+
+def constraints_1D(s: float, I: int) -> tuple[sps.csr_matrix, np.ndarray]:
     """Compute the constraints matrix A and the margins vector s in 1D.
 
     This will define the raking optimization problem:
@@ -17,7 +18,7 @@ def constraints_1D(s: float, I: int) -> tuple[np.ndarray, np.ndarray]:
         Number of possible values for categorical variable 1
     Returns
     -------
-    A : np.ndarray
+    A : scipy.sparse.csr_matrix
         1 * I constraints matrix
     s : np.ndarray
         length 1 margins vector
@@ -35,7 +36,7 @@ def constraints_1D(s: float, I: int) -> tuple[np.ndarray, np.ndarray]:
         "The number of possible values taken by the categorical variable must be higher than 1."
     )
 
-    A = np.ones((1, I))
+    A = sps.csr_matrix(np.ones((1, I)))
     s = np.array([s])
     return (A, s)
 
@@ -47,7 +48,7 @@ def constraints_2D(
     J: int,
     rtol: float = 1e-05,
     atol: float = 1e-08,
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[sps.csr_matrix, np.ndarray]:
     """Compute the constraints matrix A and the margins vector s in 2D.
 
     This will define the raking optimization problem:
@@ -70,7 +71,7 @@ def constraints_2D(
 
     Returns
     -------
-    A : np.ndarray
+    A : scipy.sparse.csr_matrix
         (I + J - 1) * (I J) constraints matrix
     s : np.ndarray
         length (I + J) margins vector
@@ -115,12 +116,13 @@ def constraints_2D(
         "The sum of the row margins must be equal to the sum of the column margins."
     )
 
-    A = np.zeros((J + I - 1, I * J))
-    for j in range(0, J):
-        for i in range(0, I - 1):
-            A[J + i, j * I + i] = 1
-            A[j, j * I + i] = 1
-        A[j, j * I + I - 1] = 1
+    identity_I = sps.csr_matrix(np.eye(I, dtype=int))
+    identity_J = sps.csr_matrix(np.eye(J, dtype=int))
+    one_I = sps.csr_matrix(np.ones((I, 1), dtype=int))
+    one_J = sps.csr_matrix(np.ones((J, 1), dtype=int))
+    A1 = sps.kron(identity_J, one_I.transpose())
+    A2 = sps.kron(one_J.transpose(), identity_I[0 : (I - 1), :])
+    A = sps.vstack([A1, A2])
     s = np.concatenate([s1, s2[0 : (I - 1)]])
     return (A, s)
 
@@ -248,6 +250,23 @@ def constraints_3D(
         "The sums of the targets for dimension 1 and 3 must be equal."
     )
 
+    identity_I = sps.csr_matrix(np.eye(I, dtype=int))
+    identity_J = sps.csr_matrix(np.eye(J, dtype=int))
+    identity_K = sps.csr_matrix(np.eye(K, dtype=int))
+    identity_JK = sps.csr_matrix(np.eye(J * K, dtype=int))
+    one_I = sps.csr_matrix(np.ones((I, 1), dtype=int))
+    one_J = sps.csr_matrix(np.ones((J, 1), dtype=int))
+    one_K = sps.csr_matrix(np.ones((K, 1), dtype=int))
+    A = []
+    A.append(sps.kron(
+        identity_K, sps.kron(identity_J[0 : (J - 1), :], one_I.transpose())
+    ))
+    A.append(sps.kron(identity_JK[J * K - 1, :], one_I.transpose()))
+    for i in range(0, I):
+        A.append(sps.kron(sps.kron(identity_K[0:(K - 1),:], one_J.transpose()), identity_I[i,:]))
+    A.append(sps.kron(one_K.transpose(), sps.kron(identity_J, identity_I[0:(I - 1),:])))
+    A = sps.vstack(A)
+
     A = np.zeros((I * J + I * K + J * K - I - J - K + 1, I * J * K))
     s = np.zeros(I * J + I * K + J * K - I - J - K + 1)
     for k in range(0, K):
@@ -321,7 +340,7 @@ def constraints_USHD(
     )
     assert J > 1, "The number of races and ethnicities must be higher than 1."
     assert isinstance(K, int), "The number of counties must be an integer."
-#    assert K > 1, "The number of counties must be higher than 1."
+    #    assert K > 1, "The number of counties must be higher than 1."
     assert K > 0, "The number of counties must be higher than 0."
 
     assert isinstance(s_cause, np.ndarray), (
@@ -393,13 +412,15 @@ def constraints_USHD_parallel(
     rtol: float = 1e-05,
     atol: float = 1e-08,
 ) -> tuple[sps.csr_matrix, np.ndarray]:
-    (A_loc, s_loc) = constraints_USHD(s_cause[0: I + 1], I, J, K, rtol, atol)
+    (A_loc, s_loc) = constraints_USHD(s_cause[0 : I + 1], I, J, K, rtol, atol)
     # Transform to sparse
     A_loc = sps.csr_matrix(A_loc)
     I_N = sps.csr_matrix(np.eye(N, dtype=int))
     A = sps.kron(I_N, A_loc)
-    s_cause = s_cause.reshape(N, I + 1, order='C')
-    s_cause = np.concatenate([s_cause[:, 1:], np.zeros((N, (I + J + 1) * K))], axis=1)
+    s_cause = s_cause.reshape(N, I + 1, order="C")
+    s_cause = np.concatenate(
+        [s_cause[:, 1:], np.zeros((N, (I + J + 1) * K))], axis=1
+    )
     s_cause = s_cause.flatten()
     return (A, s_cause)
 
@@ -460,7 +481,7 @@ def constraints_USHD_lower(
     )
     assert J > 1, "The number of races and ethnicities must be higher than 1."
     assert isinstance(K, int), "The number of counties must be an integer."
-#    assert K > 1, "The number of counties must be higher than 1."
+    #    assert K > 1, "The number of counties must be higher than 1."
     assert K > 0, "The number of counties must be higher than 0."
 
     assert isinstance(s_cause, np.ndarray), (
@@ -502,12 +523,12 @@ def constraints_USHD_lower(
         "The shape of the margins vector for the all causes deaths must be equal to the number of races multiplied by the number of counties."
     )
 
-    assert np.allclose(np.sum(s_cause), np.sum(s_county), rtol, atol), (
-        "The sum of the number of deaths per cause must be equal to the sum of the number of deaths per county."
-    )
-    assert np.allclose(np.sum(s_all_causes, axis=0), s_county, rtol, atol), (
-        "For each county, the all-races number of deaths must be equal to the sum of the number of deaths per race."
-    )
+#    assert np.allclose(np.sum(s_cause), np.sum(s_county), rtol, atol), (
+#        "The sum of the number of deaths per cause must be equal to the sum of the number of deaths per county."
+#    )
+#    assert np.allclose(np.sum(s_all_causes, axis=0), s_county, rtol, atol), (
+#        "For each county, the all-races number of deaths must be equal to the sum of the number of deaths per race."
+#    )
 
     A = np.zeros((I + K + I * K + J * K - K - 1, I * (J + 1) * K))
     s = np.zeros(I + K + I * K + J * K - K - 1)
@@ -550,20 +571,24 @@ def constraints_USHD_lower_parallel(
     rtol: float = 1e-05,
     atol: float = 1e-08,
 ) -> tuple[sps.csr_matrix, np.ndarray]:
-    s_cause_0 = s_cause[0: I]
-    s_county_0_K = s_cause_0.sum() - s_county[0: K - 1].sum()
-    s_county_0 = np.concatenate((s_county[0: K - 1], np.array([s_county_0_K])), 0)
-    s_all_causes_0 = np.reshape(s_all_causes[0: (J * K)], (J, K), 'F')
-    (A_loc, s_loc) = constraints_USHD_lower( \
-        s_cause_0, s_county_0, s_all_causes_0, I, J, K, rtol, atol)
+    s_cause_0 = s_cause[0:I]
+    s_county_0_K = s_cause_0.sum() - s_county[0 : K - 1].sum()
+    s_county_0 = np.concatenate(
+        (s_county[0 : K - 1], np.array([s_county_0_K])), 0
+    )
+    s_all_causes_0 = np.reshape(s_all_causes[0 : (J * K)], (J, K), "F")
+    (A_loc, s_loc) = constraints_USHD_lower(
+        s_cause_0, s_county_0, s_all_causes_0, I, J, K, rtol, atol
+    )
     # Transform to sparse
     A_loc = sps.csr_matrix(A_loc)
     I_N = sps.csr_matrix(np.eye(N, dtype=int))
     A = sps.kron(I_N, A_loc)
-    s_cause = s_cause.reshape(N, I, order='C')
-    s_county = s_county.reshape(N, K - 1, order='C')
-    s_all_causes = s_all_causes.reshape(N, J * K, order='C')
-    s = np.concatenate([s_cause, s_county, s_all_causes, np.zeros((N, (I - 1) * K))], axis=1)
+    s_cause = s_cause.reshape(N, I, order="C")
+    s_county = s_county.reshape(N, K - 1, order="C")
+    s_all_causes = s_all_causes.reshape(N, J * K, order="C")
+    s = np.concatenate(
+        [s_cause, s_county, s_all_causes, np.zeros((N, (I - 1) * K))], axis=1
+    )
     s = s.flatten()
     return (A, s)
-

--- a/src/raking/experimental/__init__.py
+++ b/src/raking/experimental/__init__.py
@@ -3,6 +3,10 @@ from raking.experimental.data_parallel import DataBuilderParallel
 from raking.experimental.dimension import Dimension, Space
 from raking.experimental.distance import Distance, distance_map
 from raking.experimental.solver import DualSolver, PrimalSolver
+from raking.experimental.solver_parallel import (
+    DualSolverParallel,
+    PrimalSolverParallel,
+)
 
 __all__ = [
     "DataBuilder",
@@ -12,5 +16,7 @@ __all__ = [
     "Distance",
     "distance_map",
     "DualSolver",
+    "DualSolverParallel",
     "PrimalSolver",
+    "PrimalSolverParallel",
 ]

--- a/src/raking/experimental/__init__.py
+++ b/src/raking/experimental/__init__.py
@@ -1,10 +1,12 @@
 from raking.experimental.data import DataBuilder
+from raking.experimental.data_parallel import DataBuilderParallel
 from raking.experimental.dimension import Dimension, Space
 from raking.experimental.distance import Distance, distance_map
 from raking.experimental.solver import DualSolver, PrimalSolver
 
 __all__ = [
     "DataBuilder",
+    "DataBuilderParallel",
     "Dimension",
     "Space",
     "Distance",

--- a/src/raking/experimental/__init__.py
+++ b/src/raking/experimental/__init__.py
@@ -16,7 +16,7 @@ __all__ = [
     "Distance",
     "distance_map",
     "DualSolver",
-    "DualSolverParallel",
     "PrimalSolver",
+    "DualSolverParallel",
     "PrimalSolverParallel",
 ]

--- a/src/raking/experimental/data.py
+++ b/src/raking/experimental/data.py
@@ -31,13 +31,17 @@ class Data(TypedDict):
     vec_u : numpy.typing.NDArray
         Upper bounds for the observations that are not constraints (including aggregates).
     mat_m : scipy.sparse.csc_matrix
-        Matrix indicating how to sum the observations to get the margins that are not constraints.
+        Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
+        to get the margins that are not constraints.
     mat_c : scipy.sparse.csc_matrix
-        Matrix indicating how to sum the observations to get the constraints.
+        Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
+        to get the constraints.
     mat_mc1 : scipy.sparse.csr_matrix
-        Matrix indicating how to sum the observations that are not missing to get margins and constraints.
+        Matrix indicating how to sum the non-missing observations that are not constraints nor margins
+        to get margins and constraints.
     mat_mc2 : scipy.sparse.csr_matrix
-        Matrix indicating how to sum the observations that are missing to get margins and constraints.
+        Matrix indicating how to sum the missing observations that are not constraints nor margins
+        to get margins and constraints.
     mat_q : numpy.typing.NDArray
     span : pandas.DataFrame
         Contains the values taken by the categorical variables in the raking problem (excluding aggregates).
@@ -114,6 +118,7 @@ class DataBuilder(BaseModel):
 
         index = df_observ["is_margin"]
         data["vec_p"] = (df_observ[~index][self.weights] > 0).to_numpy()
+        # data["vec_init"] = df_observ[~index][self.value].to_numpy() * data["vec_p"]
         data["mat_m"] = _build_design_mat(df_observ[index], self.space)
 
         index = df_observ.eval(f"{self.weights} > 0")

--- a/src/raking/experimental/data.py
+++ b/src/raking/experimental/data.py
@@ -8,12 +8,10 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import scipy.sparse as sps
+from pandas.api.types import CategoricalDtype
 from pydantic import BaseModel
 
 from raking.experimental.dimension import Dimension, Space
-
-# pd.set_option("future.no_silent_downcasting", True)
-
 
 class Data(TypedDict):
     """Observations and constraints for the optimization problem.
@@ -193,11 +191,20 @@ class DataBuilder(BaseModel):
 
     def _sort_rows(self, df: pd.DataFrame) -> pd.DataFrame:
         """Sort the rows of the data frame by constraint status, margin status and categorical variable."""
-        columns = [f"{name}_order" for name in self.space.names]
-        for column, dim in zip(columns, self.space.dimensions):
-            df[column] = df[dim.name].map(dim.order)
+        columns = [name for name in self.space.names]
+        column_types = []
+        for dim in self.space.dimensions:
+            column_types.append(df[dim.name].dtypes)
+            dim_names = df[dim.name].unique().tolist()
+            if dim.null in dim_names:
+                dim_names.remove(dim.null)
+            dim_ordering = dim_names + [dim.null]
+            df[dim.name] = df[dim.name].astype(
+                CategoricalDtype(categories=dim_ordering, ordered=True)
+            )
         df = df.sort_values(["is_constr", "level"] + columns, ignore_index=True)
-        df = df.drop(columns=columns)
+        for (dim, column_type) in zip(self.space.dimensions, column_types):
+            df[dim.name] = df[dim.name].astype(column_type)
         return df
 
     def _expand_observ(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/src/raking/experimental/data.py
+++ b/src/raking/experimental/data.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from raking.experimental.dimension import Dimension, Space
 
+
 class Data(TypedDict):
     """Observations and constraints for the optimization problem.
 
@@ -125,7 +126,9 @@ class DataBuilder(BaseModel):
 
         index = df_observ["is_margin"]
         data["vec_p"] = (df_observ[~index][self.weights] > 0).to_numpy()
-        data["vec_init"] = df_observ[~index][self.value].to_numpy() * data["vec_p"]
+        data["vec_init"] = (
+            df_observ[~index][self.value].to_numpy() * data["vec_p"]
+        )
         data["mat_m"] = _build_design_mat(df_observ[index], self.space)
 
         index = df_observ.eval(f"{self.weights} > 0")
@@ -215,7 +218,7 @@ class DataBuilder(BaseModel):
                 CategoricalDtype(categories=dim_ordering, ordered=True)
             )
         df = df.sort_values(["is_constr", "level"] + columns, ignore_index=True)
-        for (dim, column_type) in zip(self.space.dimensions, column_types):
+        for dim, column_type in zip(self.space.dimensions, column_types):
             df[dim.name] = df[dim.name].astype(column_type)
         return df
 

--- a/src/raking/experimental/data.py
+++ b/src/raking/experimental/data.py
@@ -30,6 +30,8 @@ class Data(TypedDict):
         Lower bounds for the observations that are not constraints (including aggregates).
     vec_u : numpy.typing.NDArray
         Upper bounds for the observations that are not constraints (including aggregates).
+    vec_init: numpy.typing.NDArray
+        Initial guess for the unknown raked values.
     mat_m : scipy.sparse.csc_matrix
         Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
         to get the margins that are not constraints.
@@ -38,11 +40,15 @@ class Data(TypedDict):
         to get the constraints.
     mat_mc1 : scipy.sparse.csr_matrix
         Matrix indicating how to sum the non-missing observations that are not constraints nor margins
-        to get margins and constraints.
+        to get margins and constraints. Stack of mat_c and mat_c, keeping only the rows corresponding
+        to the non-missing observations.
     mat_mc2 : scipy.sparse.csr_matrix
         Matrix indicating how to sum the missing observations that are not constraints nor margins
-        to get margins and constraints.
+        to get margins and constraints. Stack of mat_c and mat_c, keeping only the rows corresponding
+        to the missing observations.
     mat_q : numpy.typing.NDArray
+        Matrix indicating how to get the missing observations once we know the raked margins and the constraints.
+        Should be equal to [mat_mc2^T mat_mc2]-1
     span : pandas.DataFrame
         Contains the values taken by the categorical variables in the raking problem (excluding aggregates).
     """
@@ -53,9 +59,10 @@ class Data(TypedDict):
     vec_b: npt.NDArray
     vec_l: npt.NDArray | None
     vec_u: npt.NDArray | None
+    vec_init: npt.NDArray
+
     mat_m: sps.csc_matrix
     mat_c: sps.csc_matrix
-
     mat_mc1: sps.csc_matrix
     mat_mc2: sps.csr_matrix
     mat_q: npt.NDArray
@@ -118,7 +125,7 @@ class DataBuilder(BaseModel):
 
         index = df_observ["is_margin"]
         data["vec_p"] = (df_observ[~index][self.weights] > 0).to_numpy()
-        # data["vec_init"] = df_observ[~index][self.value].to_numpy() * data["vec_p"]
+        data["vec_init"] = df_observ[~index][self.value].to_numpy() * data["vec_p"]
         data["mat_m"] = _build_design_mat(df_observ[index], self.space)
 
         index = df_observ.eval(f"{self.weights} > 0")

--- a/src/raking/experimental/data.py
+++ b/src/raking/experimental/data.py
@@ -260,8 +260,8 @@ class DataBuilder(BaseModel):
     def _check_constr(self, df: pd.DataFrame) -> pd.DataFrame:
         """Check if the constraints are consistent."""
         df = df.copy()
-        df["index"] = df.index
-        df["source"] = [(i,) for i in df["index"]]
+        df["df_index"] = df.index
+        df["source"] = [(i,) for i in df["df_index"]]
         df["included"] = True
         df_by_level = {
             i: df.query(f"level == {i}").reset_index(drop=True)
@@ -284,7 +284,7 @@ class DataBuilder(BaseModel):
             df_by_level[j] = df_j
 
         df = pd.concat(df_by_level.values(), axis=0, ignore_index=True)
-        df = df.query("index != -1").reset_index(drop=True)
+        df = df.query("df_index != -1").reset_index(drop=True)
         return df
 
     def _check_sufficiency(self, mat: sps.csc_matrix) -> npt.NDArray:
@@ -320,7 +320,7 @@ def _resolve_same_level_duplicity(
         if not np.allclose(df_check[value], df_check[f"{value}_alt"]):
             raise ValueError("Constraints are not consistent")
 
-        index = df_i["index"].isin(df_dup["source"].map(max))
+        index = df_i["df_index"].isin(df_dup["source"].map(max))
         df_i.loc[index, "included"] = False
     return df_i, df_i_to_j
 
@@ -353,7 +353,7 @@ def _resolve_upper_level_duplicity(
     index = df_cmp.eval(f"{value}_alt.notna()")
     df_cmp.loc[index, "included"] = False
     df_cmp.loc[index, "source"] = df_cmp.loc[index, "source_alt"]
-    df_cmp["index"] = df_cmp["index"].fillna(-1).astype(int)
+    df_cmp["df_index"] = df_cmp["df_index"].fillna(-1).astype(int)
     return df_cmp[df_j.columns].copy()
 
 
@@ -399,21 +399,49 @@ def _build_design_mat(df: pd.DataFrame, space: Space) -> sps.csc_matrix:
     """Returns a matrix indicating how to sum the observations to get the aggregates."""
     df = df.reset_index(drop=True)
     mat_shape = (len(df), space.size)
+    df_index = (
+        df.copy(deep=True).reset_index().rename(columns={"index": "row_index"})
+    )
 
-    row_indices = np.empty(shape=(0,), dtype=int)
-    col_indices = np.empty(shape=(0,), dtype=int)
-
-    for i, row in df.iterrows():
-        col_index = np.asarray(
-            space.index(tuple(row[name] for name in space.names))
+    for dim in space.dimensions:
+        dim_index = pd.DataFrame(
+            {
+                f"{dim.name}_index": np.arange(len(dim.grid)),
+                f"{dim.name}_value": dim.grid,
+            }
         )
-        row_index = np.asarray([i] * col_index.size)
+        dim_index_margin = dim_index.copy(deep=True)
+        dim_index_margin[f"{dim.name}_value"] = dim.null
+        dim_index = pd.concat(
+            [dim_index, dim_index_margin], axis=0, ignore_index=True
+        )
+        df_index = df_index.merge(
+            dim_index,
+            left_on=dim.name,
+            right_on=f"{dim.name}_value",
+            how="left",
+        )
 
-        row_indices = np.hstack([row_indices, row_index])
-        col_indices = np.hstack([col_indices, col_index])
+    shifts = np.cumprod([1] + [dim.size for dim in space.dimensions[1:][::-1]])[
+        ::-1
+    ]
+    df_index["col_index"] = (
+        df_index[[f"{dim.name}_index" for dim in space.dimensions]]
+        .to_numpy()
+        .dot(shifts)
+    )
 
-    val = np.ones_like(row_indices, dtype=int)
-    return sps.csc_matrix((val, (row_indices, col_indices)), shape=mat_shape)
+    mat = sps.csc_matrix(
+        (
+            np.ones(len(df_index)),
+            (
+                df_index["row_index"].to_numpy(),
+                df_index["col_index"].to_numpy(),
+            ),
+        ),
+        shape=mat_shape,
+    )
+    return mat
 
 
 def _extract_independent_rows(

--- a/src/raking/experimental/data_parallel.py
+++ b/src/raking/experimental/data_parallel.py
@@ -1,0 +1,177 @@
+"""Data classes."""
+
+import itertools
+import operator
+from typing import TypedDict
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import scipy.sparse as sps
+from pandas.api.types import CategoricalDtype
+from pydantic import BaseModel
+
+from raking.experimental.data import Data, DataBuilder, _build_design_mat
+from raking.experimental.dimension import Dimension, Space
+
+
+class DataParallel(TypedDict):
+    """Observations and constraints for the optimization problem.
+
+    Parameters
+    ----------
+    vec_p : numpy.typing.NDArray
+        Indicates whether observations that are not constraints nor margins are missing.
+    vec_y : numpy.typing.NDArray
+        Vector containing the values of the observations that are not constraints and not missing.
+    vec_w : numpy.typing.NDArray
+        Vector containing the weights corresponding to the observations in vec_y. Must be > 0 and < np.inf.
+    vec_b : numpy.typing.NDArray
+        Vector containing the values of the constraints.
+    vec_l : numpy.typing.NDArray
+        Lower bounds for the observations that are not constraints (including aggregates).
+    vec_u : numpy.typing.NDArray
+        Upper bounds for the observations that are not constraints (including aggregates).
+    mat_m : scipy.sparse.csc_matrix
+        Matrix indicating how to sum the observations to get the margins that are not constraints.
+    mat_c : scipy.sparse.csc_matrix
+        Matrix indicating how to sum the observations to get the constraints.
+    mat_mc1 : scipy.sparse.csr_matrix
+        Matrix indicating how to sum the observations that are not missing to get margins and constraints.
+    mat_mc2 : scipy.sparse.csr_matrix
+        Matrix indicating how to sum the observations that are missing to get margins and constraints.
+    mat_q : numpy.typing.NDArray
+    """
+
+    vec_p: npt.NDArray
+    vec_y: npt.NDArray
+    vec_w: npt.NDArray
+    vec_b: npt.NDArray
+    vec_l: npt.NDArray | None
+    vec_u: npt.NDArray | None
+    mat_m: sps.csc_matrix
+    mat_c: sps.csc_matrix
+
+    mat_mc1: sps.csc_matrix
+    mat_mc2: sps.csr_matrix
+    mat_q: npt.NDArray
+
+class DataBuilderParallel(BaseModel):
+    """Specify observations and constraints for the optimization problem.
+
+    Parameters
+    ----------
+    dim_specs : dict
+        Keys = Categorical variables. Values = Code corresponding to the aggregate all categories.
+        Example: If we rake each cause to all causes (encoded by -1): dim_specs={'cause': -1}
+    dim_parallel : list
+        List of categorical variables over which we want to loop the raking process.
+        Example: draws, years, age groups.
+    value : str
+        Name of the column containing the initial observations in the initial data frame.
+    weights : str
+        Name of the column containing the weights in the initial data frame.
+    bounds : tuple[str, str]
+        Names of the columns containing the lower and upper bounds (if using logistic distance).
+    """
+
+    dim_specs: dict[str, int | str]
+    dim_parallel: list
+    value: str
+    weights: str
+    bounds: tuple[str, str] | None = None
+
+    def build(self, df: pd.DataFrame) -> DataParallel:
+        """Build the observations and constraints for the optimization problem.
+
+        Parameters
+        ----------
+        df : pandas DataFrame
+            Contains one column for each of the keys in self.dim_specs and self.dim_parallel,
+            one column for the 'value', one column for the 'weights'
+            and optionally two columns for the 'bounds'.
+
+        Returns
+        -------
+        data : raking.experimental.data_parallel.DataParallel
+            Contains observations data and constraints for the optimization problem.
+        """
+        data = {}
+
+        # Take the first data set and build the corresponding single data builder
+        df_loc = df.copy(deep=True)
+        for dim in self.dim_parallel:
+            dim0 = df[dim].unique().tolist()[0]
+            df_loc = df_loc.loc[df_loc[dim]==dim0]
+            df_loc = df_loc.drop(columns=[dim])
+        data_builder = DataBuilder(dim_specs=self.dim_specs, value=self.value, weights=self.weights, bounds=self.bounds)
+        data_builder._build_space(df_loc)
+        df_loc = (
+            df_loc.pipe(data_builder._subset_columns)
+                  .pipe(data_builder._check_duplication)
+                  .pipe(data_builder._check_weights)
+                  .pipe(data_builder._check_value)
+                  .pipe(data_builder._assign_level)
+                  .pipe(data_builder._assign_indicators)
+                  .pipe(data_builder._sort_rows)
+        )
+        df_observ, df_constr = df_loc.query("~is_constr"), df_loc.query("is_constr")
+        df_observ = data_builder._expand_observ(df_observ)
+        df_constr = data_builder._check_constr(df_constr)
+
+        index = df_observ["is_margin"]
+        vec_p_loc = (df_observ[~index][self.weights] > 0).to_numpy()
+        mat_m_loc = _build_design_mat(df_observ[index], data_builder.space)
+
+        index = df_observ.eval(f"{self.weights} > 0")
+        columns = [name for name in data_builder.space.names]
+        vec_yw_loc = df_observ[index][columns]
+
+        index = df_constr["included"]
+        mat_c_loc = _build_design_mat(df_constr[index], data_builder.space)
+        vec_b_loc = df_constr[index][columns]
+
+        mat_mc_loc = sps.csc_matrix(sps.vstack([mat_m_loc, mat_c_loc]))
+        mat_mc1_loc = sps.csc_matrix(mat_mc_loc[:, vec_p_loc])
+        mat_mc2_loc = sps.csc_matrix(mat_mc_loc[:, ~vec_p_loc])
+        mat_q_loc = data_builder._check_sufficiency(mat_mc2_loc)
+
+        span_loc = data_builder.space.span().copy()
+
+        # For the matrices, take Kronecker product with identity matrix
+        N = 1
+        for dim in self.dim_parallel:
+            N = N * len(df[dim].unique())
+        data["mat_m"] = sps.kron(sps.eye(N, N), mat_m_loc)
+        data["mat_c"] = sps.kron(sps.eye(N, N), mat_c_loc)
+        data["mat_mc1"] = sps.kron(sps.eye(N, N), mat_mc1_loc)
+        data["mat_mc2"] = sps.kron(sps.eye(N, N), mat_mc2_loc)
+        data["mat_q"] = sps.kron(sps.eye(N, N), mat_q_loc)
+
+        # For logical vectors, concatenate
+        data["vec_p"] = np.tile(vec_p_loc, N)
+
+        # For the other vectors, keep the order of the rows
+        vec_yw = pd.concat([vec_yw_loc]*N)
+        vec_b = pd.concat([vec_b_loc]*N)
+        span = pd.concat([span_loc]*N)
+        dim_values = []
+        for dim in self.dim_parallel:
+            dim_values.append(df[dim].unique().tolist())
+        parallel = pd.DataFrame(list(itertools.product(*dim_values)), columns=self.dim_parallel)
+        for dim in self.dim_parallel:
+            vec_yw[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_yw_loc))
+            vec_b[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_b_loc))
+            span[dim] = np.repeat(parallel[dim].to_numpy(), len(span_loc))
+        data["vec_y"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[self.value].to_numpy()
+        data["vec_w"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[self.weights].to_numpy()
+        data["vec_b"] = vec_b.merge(df, on=columns + self.dim_parallel, how="inner")[self.value].to_numpy()
+        data["vec_l"], data["vec_u"] = None, None
+        if self.bounds is not None:
+            lb, ub = self.bounds
+            data["vec_l"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[lb].to_numpy()
+            data["vec_u"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[ub].to_numpy()
+        data["span"] = span
+        
+        return data
+

--- a/src/raking/experimental/data_parallel.py
+++ b/src/raking/experimental/data_parallel.py
@@ -1,18 +1,15 @@
 """Data classes."""
 
 import itertools
-import operator
 from typing import TypedDict
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import scipy.sparse as sps
-from pandas.api.types import CategoricalDtype
 from pydantic import BaseModel
 
-from raking.experimental.data import Data, DataBuilder, _build_design_mat
-from raking.experimental.dimension import Dimension, Space
+from raking.experimental.data import DataBuilder, _build_design_mat
 
 
 class DataParallel(TypedDict):
@@ -40,6 +37,9 @@ class DataParallel(TypedDict):
     mat_c : scipy.sparse.csc_matrix
         Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
         to get the constraints.
+    mat_s : scipy.sparse.csc_matrix
+        Matrix indicating how to get from the missing and non-missing, non-constraints, non-margins observations
+        to the non-missing, non-constraints, non-margins observations
     mat_mc1 : scipy.sparse.csr_matrix
         Matrix indicating how to sum the non-missing observations that are not constraints nor margins
         to get margins and constraints.
@@ -61,11 +61,13 @@ class DataParallel(TypedDict):
 
     mat_m: sps.csc_matrix
     mat_c: sps.csc_matrix
+    mat_s: sps.csc_matrix
     mat_mc1: sps.csc_matrix
     mat_mc2: sps.csr_matrix
     mat_q: npt.NDArray
 
     span: pd.DataFrame
+
 
 class DataBuilderParallel(BaseModel):
     """Specify observations and constraints for the optimization problem.
@@ -113,20 +115,28 @@ class DataBuilderParallel(BaseModel):
         df_loc = df.copy(deep=True)
         for dim in self.dim_parallel:
             dim0 = df[dim].unique().tolist()[0]
-            df_loc = df_loc.loc[df_loc[dim]==dim0]
+            df_loc = df_loc.loc[df_loc[dim] == dim0]
             df_loc = df_loc.drop(columns=[dim])
-        data_builder = DataBuilder(dim_specs=self.dim_specs, value=self.value, weights=self.weights, bounds=self.bounds)
+        data_builder = DataBuilder(
+            dim_specs=self.dim_specs,
+            value=self.value,
+            weights=self.weights,
+            bounds=self.bounds,
+        )
         data_builder._build_space(df_loc)
         df_loc = (
             df_loc.pipe(data_builder._subset_columns)
-                  .pipe(data_builder._check_duplication)
-                  .pipe(data_builder._check_weights)
-                  .pipe(data_builder._check_value)
-                  .pipe(data_builder._assign_level)
-                  .pipe(data_builder._assign_indicators)
-                  .pipe(data_builder._sort_rows)
+            .pipe(data_builder._check_duplication)
+            .pipe(data_builder._check_weights)
+            .pipe(data_builder._check_value)
+            .pipe(data_builder._assign_level)
+            .pipe(data_builder._assign_indicators)
+            .pipe(data_builder._sort_rows)
         )
-        df_observ, df_constr = df_loc.query("~is_constr"), df_loc.query("is_constr")
+        df_observ, df_constr = (
+            df_loc.query("~is_constr"),
+            df_loc.query("is_constr"),
+        )
         df_observ = data_builder._expand_observ(df_observ)
         df_constr = data_builder._check_constr(df_constr)
 
@@ -135,29 +145,66 @@ class DataBuilderParallel(BaseModel):
         columns = [name for name in data_builder.space.names]
         vec_init_loc = df_observ[~index][columns]
         vec_init_loc["vec_init"] = vec_p_loc
-        mat_m_loc = _build_design_mat(df_observ[index], data_builder.space)
+        mat_m = _build_design_mat(df_observ[index], data_builder.space)
 
         index = df_observ.eval(f"{self.weights} > 0")
         columns = [name for name in data_builder.space.names]
         vec_yw_loc = df_observ[index][columns]
 
         index = df_constr["included"]
-        mat_c_loc = _build_design_mat(df_constr[index], data_builder.space)
+        mat_c = _build_design_mat(df_constr[index], data_builder.space)
         vec_b_loc = df_constr[index][columns]
 
-        mat_mc_loc = sps.csc_matrix(sps.vstack([mat_m_loc, mat_c_loc]))
-        mat_mc1_loc = sps.csc_matrix(mat_mc_loc[:, vec_p_loc])
-        mat_mc2_loc = sps.csc_matrix(mat_mc_loc[:, ~vec_p_loc])
+        mat_mc = sps.csc_matrix(sps.vstack([mat_m, mat_c]))
+        mat_mc1_loc = sps.csc_matrix(mat_mc[:, vec_p_loc])
+        mat_mc2_loc = sps.csc_matrix(mat_mc[:, ~vec_p_loc])
         mat_q_loc = data_builder._check_sufficiency(mat_mc2_loc)
 
+        # Build the matrices and vectors for the primal problem
+        size_v, size_r = vec_p_loc.size, vec_p_loc.sum()
+        mat_s = sps.csr_matrix(
+            (
+                np.ones(size_r, dtype=int),
+                (
+                    np.arange(size_r, dtype=int),
+                    np.arange(size_v, dtype=int)[vec_p_loc],
+                ),
+            ),
+            shape=(size_r, size_v),
+        )
+        mat_o_primal_loc = sps.csr_matrix(sps.vstack([mat_s, mat_m]))
+        mat_c_primal_loc = mat_c.copy()
+        vec_c_primal_loc = vec_b_loc.copy()
+
+        # Build the matrices and vectors for the dual problem
+        size_m, size_c = mat_m.shape[0], mat_c.shape[0]
+        mat_o_dual_loc = sps.csr_matrix(
+            sps.vstack([-mat_mc1_loc.T, sps.eye(size_m, n=size_m + size_c)])
+        )
+        dict_vec_o_dual = {}
+        for column in columns:
+            dict_vec_o_dual[column] = np.repeat(np.nan, size_m)
+        vec_o_dual_loc = pd.DataFrame(dict_vec_o_dual)
+        vec_o_dual_loc = pd.concat([vec_o_dual_loc, vec_b_loc])
+        mat_c_dual_loc = mat_mc2_loc.T
+        vec_c_dual_loc = np.zeros(mat_c_dual_loc.shape[0])
+
+        # Save the span of the first data set
         span_loc = data_builder.space.span().copy()
 
         # For the matrices, take Kronecker product with identity matrix
         N = 1
         for dim in self.dim_parallel:
             N = N * len(df[dim].unique())
-        data["mat_m"] = sps.kron(sps.eye(N, N), mat_m_loc)
-        data["mat_c"] = sps.kron(sps.eye(N, N), mat_c_loc)
+        data["N"] = N
+
+        # Primal problem
+        data["mat_o_primal"] = sps.kron(sps.eye(N, N), mat_o_primal_loc)
+        data["mat_c_primal"] = sps.kron(sps.eye(N, N), mat_c_primal_loc)
+
+        # Dual problem
+        data["mat_o_dual"] = sps.kron(sps.eye(N, N), mat_o_dual_loc)
+        data["mat_c_dual"] = sps.kron(sps.eye(N, N), mat_c_dual_loc)
         data["mat_mc1"] = sps.kron(sps.eye(N, N), mat_mc1_loc)
         data["mat_mc2"] = sps.kron(sps.eye(N, N), mat_mc2_loc)
         data["mat_q"] = sps.kron(sps.eye(N, N), mat_q_loc)
@@ -166,31 +213,73 @@ class DataBuilderParallel(BaseModel):
         data["vec_p"] = np.tile(vec_p_loc, N)
 
         # For the other vectors, keep the order of the rows
-        vec_init = pd.concat([vec_init_loc]*N)
-        vec_yw = pd.concat([vec_yw_loc]*N)
-        vec_b = pd.concat([vec_b_loc]*N)
-        span = pd.concat([span_loc]*N)
         dim_values = []
         for dim in self.dim_parallel:
             dim_values.append(df[dim].unique().tolist())
-        parallel = pd.DataFrame(list(itertools.product(*dim_values)), columns=self.dim_parallel)
+        parallel = pd.DataFrame(
+            list(itertools.product(*dim_values)), columns=self.dim_parallel
+        )
+
+        # Both problems
+        vec_init = pd.concat([vec_init_loc] * N)
+        vec_yw = pd.concat([vec_yw_loc] * N)
+        span = pd.concat([span_loc] * N)
         for dim in self.dim_parallel:
-            vec_init[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_init_loc))
+            vec_init[dim] = np.repeat(
+                parallel[dim].to_numpy(), len(vec_init_loc)
+            )
             vec_yw[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_yw_loc))
-            vec_b[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_b_loc))
             span[dim] = np.repeat(parallel[dim].to_numpy(), len(span_loc))
-        vec_init = vec_init.merge(df, on=columns + self.dim_parallel, how="inner").fillna(0.0)
+        vec_init = vec_init.merge(
+            df, on=columns + self.dim_parallel, how="inner"
+        ).fillna(0.0)
         vec_init[self.value] = vec_init[self.value].fillna(0.0)
         data["vec_init"] = vec_init[self.value] * vec_init["vec_init"]
-        data["vec_y"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[self.value].to_numpy()
-        data["vec_w"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[self.weights].to_numpy()
-        data["vec_b"] = vec_b.merge(df, on=columns + self.dim_parallel, how="inner")[self.value].to_numpy()
+        data["vec_y"] = vec_yw.merge(
+            df, on=columns + self.dim_parallel, how="inner"
+        )[self.value].to_numpy()
+        data["vec_w"] = vec_yw.merge(
+            df, on=columns + self.dim_parallel, how="inner"
+        )[self.weights].to_numpy()
         data["vec_l"], data["vec_u"] = None, None
         if self.bounds is not None:
             lb, ub = self.bounds
-            data["vec_l"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[lb].to_numpy()
-            data["vec_u"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[ub].to_numpy()
+            data["vec_l"] = vec_yw.merge(
+                df, on=columns + self.dim_parallel, how="inner"
+            )[lb].to_numpy()
+            data["vec_u"] = vec_yw.merge(
+                df, on=columns + self.dim_parallel, how="inner"
+            )[ub].to_numpy()
         data["span"] = span
-        
-        return data
 
+        # Primal problem
+        vec_c_primal = pd.concat([vec_c_primal_loc] * N)
+        for dim in self.dim_parallel:
+            vec_c_primal[dim] = np.repeat(
+                parallel[dim].to_numpy(), len(vec_c_primal_loc)
+            )
+        data["vec_c_primal"] = vec_c_primal.merge(
+            df, on=columns + self.dim_parallel, how="inner"
+        )[self.value].to_numpy()
+
+        # Dual problem
+        vec_o_dual = pd.concat([vec_o_dual_loc] * N)
+        vec_b = pd.concat([vec_b_loc] * N)
+        for dim in self.dim_parallel:
+            vec_o_dual[dim] = np.repeat(
+                parallel[dim].to_numpy(), len(vec_o_dual_loc)
+            )
+            vec_b[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_b_loc))
+        data["vec_o_dual"] = (
+            vec_o_dual.merge(df, on=columns + self.dim_parallel, how="left")[
+                self.value
+            ]
+            .fillna(0.0)
+            .to_numpy()
+        )
+        data["vec_b"] = vec_b.merge(
+            df, on=columns + self.dim_parallel, how="inner"
+        )[self.value].to_numpy()
+        data["vec_c_dual"] = np.tile(vec_c_dual_loc, N)
+
+        return data

--- a/src/raking/experimental/data_parallel.py
+++ b/src/raking/experimental/data_parallel.py
@@ -32,15 +32,23 @@ class DataParallel(TypedDict):
         Lower bounds for the observations that are not constraints (including aggregates).
     vec_u : numpy.typing.NDArray
         Upper bounds for the observations that are not constraints (including aggregates).
+    vec_initi: numpy.typing.NDArray
+        Initial guess for the unknown raked values.
     mat_m : scipy.sparse.csc_matrix
-        Matrix indicating how to sum the observations to get the margins that are not constraints.
+        Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
+        to get the margins that are not constraints.
     mat_c : scipy.sparse.csc_matrix
-        Matrix indicating how to sum the observations to get the constraints.
+        Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
+        to get the constraints.
     mat_mc1 : scipy.sparse.csr_matrix
-        Matrix indicating how to sum the observations that are not missing to get margins and constraints.
+        Matrix indicating how to sum the non-missing observations that are not constraints nor margins
+        to get margins and constraints.
     mat_mc2 : scipy.sparse.csr_matrix
-        Matrix indicating how to sum the observations that are missing to get margins and constraints.
+        Matrix indicating how to sum the missing observations that are not constraints nor margins
+        to get margins and constraints.
     mat_q : numpy.typing.NDArray
+    span : pandas.DataFrame
+        Contains the values taken by the categorical variables in the raking problem (excluding aggregates).
     """
 
     vec_p: npt.NDArray
@@ -49,12 +57,15 @@ class DataParallel(TypedDict):
     vec_b: npt.NDArray
     vec_l: npt.NDArray | None
     vec_u: npt.NDArray | None
+    vec_init: npt.NDArray
+
     mat_m: sps.csc_matrix
     mat_c: sps.csc_matrix
-
     mat_mc1: sps.csc_matrix
     mat_mc2: sps.csr_matrix
     mat_q: npt.NDArray
+
+    span: pd.DataFrame
 
 class DataBuilderParallel(BaseModel):
     """Specify observations and constraints for the optimization problem.
@@ -121,6 +132,9 @@ class DataBuilderParallel(BaseModel):
 
         index = df_observ["is_margin"]
         vec_p_loc = (df_observ[~index][self.weights] > 0).to_numpy()
+        columns = [name for name in data_builder.space.names]
+        vec_init_loc = df_observ[~index][columns]
+        vec_init_loc["vec_init"] = vec_p_loc
         mat_m_loc = _build_design_mat(df_observ[index], data_builder.space)
 
         index = df_observ.eval(f"{self.weights} > 0")
@@ -152,6 +166,7 @@ class DataBuilderParallel(BaseModel):
         data["vec_p"] = np.tile(vec_p_loc, N)
 
         # For the other vectors, keep the order of the rows
+        vec_init = pd.concat([vec_init_loc]*N)
         vec_yw = pd.concat([vec_yw_loc]*N)
         vec_b = pd.concat([vec_b_loc]*N)
         span = pd.concat([span_loc]*N)
@@ -160,9 +175,13 @@ class DataBuilderParallel(BaseModel):
             dim_values.append(df[dim].unique().tolist())
         parallel = pd.DataFrame(list(itertools.product(*dim_values)), columns=self.dim_parallel)
         for dim in self.dim_parallel:
+            vec_init[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_init_loc))
             vec_yw[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_yw_loc))
             vec_b[dim] = np.repeat(parallel[dim].to_numpy(), len(vec_b_loc))
             span[dim] = np.repeat(parallel[dim].to_numpy(), len(span_loc))
+        vec_init = vec_init.merge(df, on=columns + self.dim_parallel, how="inner").fillna(0.0)
+        vec_init[self.value] = vec_init[self.value].fillna(0.0)
+        data["vec_init"] = vec_init[self.value] * vec_init["vec_init"]
         data["vec_y"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[self.value].to_numpy()
         data["vec_w"] = vec_yw.merge(df, on=columns + self.dim_parallel, how="inner")[self.weights].to_numpy()
         data["vec_b"] = vec_b.merge(df, on=columns + self.dim_parallel, how="inner")[self.value].to_numpy()

--- a/src/raking/experimental/data_parallel.py
+++ b/src/raking/experimental/data_parallel.py
@@ -17,29 +17,36 @@ class DataParallel(TypedDict):
 
     Parameters
     ----------
+    N: int
+        Parallelization dimension. Number of times that the problem needs to be repeated.
     vec_p : numpy.typing.NDArray
         Indicates whether observations that are not constraints nor margins are missing.
+    vec_init: numpy.typing.NDArray
+        Initial guess for the unknown raked values.
     vec_y : numpy.typing.NDArray
         Vector containing the values of the observations that are not constraints and not missing.
     vec_w : numpy.typing.NDArray
         Vector containing the weights corresponding to the observations in vec_y. Must be > 0 and < np.inf.
-    vec_b : numpy.typing.NDArray
-        Vector containing the values of the constraints.
     vec_l : numpy.typing.NDArray
         Lower bounds for the observations that are not constraints (including aggregates).
     vec_u : numpy.typing.NDArray
         Upper bounds for the observations that are not constraints (including aggregates).
-    vec_initi: numpy.typing.NDArray
-        Initial guess for the unknown raked values.
-    mat_m : scipy.sparse.csc_matrix
-        Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
-        to get the margins that are not constraints.
-    mat_c : scipy.sparse.csc_matrix
-        Matrix indicating how to sum the observations that are not constraints nor margins (missing and non-missing)
-        to get the constraints.
-    mat_s : scipy.sparse.csc_matrix
-        Matrix indicating how to get from the missing and non-missing, non-constraints, non-margins observations
-        to the non-missing, non-constraints, non-margins observations
+    vec_c_primal: numpy.typing.NDArray
+        Contains the constraints for the primal problem formulation.
+    vec_o_dual: numpy.typing.NDarray
+        Used in the dot product with the unknown in the objective function for the dual problem formulation.
+    vec_c_dual: numpy.typing.NDArray
+        Contains the constraints for the dual problem formulation.
+    vec_b : numpy.typing.NDArray
+        Vector containing the values of the constraints.
+    mat_o_primal: scipy.sparse.csc_matrix
+        Used in the matrix product with the unknown in the objective function for the primal problem formulation.
+    mat_c_primal: scipy.sparse.csc_matrix
+        Matrix indicating how to sum the unknowns to get the constriants for the primal problem formulation.
+    mat_o_dual: scipy.sparse.csc_matrix
+        Used in the matrix product with the unknown in the objective function for the dual problem formulation.
+    mat_c_dual: scipy.sparse.csc_matrix
+        Matrix indicating how to sum the unknowns to get the constriants for the dual problem formulation.
     mat_mc1 : scipy.sparse.csr_matrix
         Matrix indicating how to sum the non-missing observations that are not constraints nor margins
         to get margins and constraints.
@@ -51,23 +58,27 @@ class DataParallel(TypedDict):
         Contains the values taken by the categorical variables in the raking problem (excluding aggregates).
     """
 
+    N: int
     vec_p: npt.NDArray
+    vec_init: npt.NDArray
     vec_y: npt.NDArray
     vec_w: npt.NDArray
-    vec_b: npt.NDArray
     vec_l: npt.NDArray | None
     vec_u: npt.NDArray | None
-    vec_init: npt.NDArray
+    vec_c_primal: npt.NDArray
+    vec_o_dual: npt.NDArray
+    vec_c_dual: npt.NDArray
+    vec_b: npt.NDArray
 
-    mat_m: sps.csc_matrix
-    mat_c: sps.csc_matrix
-    mat_s: sps.csc_matrix
-    mat_mc1: sps.csc_matrix
+    mat_o_primal: sps.csc_matrix
+    mat_c_primal: sps.csc_matrix
+    mat_o_dual: sps.csc_matrix
+    mat_c_dual: sps.csc_matrix
+    may_mc1: sps.csc_matrix
     mat_mc2: sps.csr_matrix
-    mat_q: npt.NDArray
+    mat_q: sps.csr_matrix
 
     span: pd.DataFrame
-
 
 class DataBuilderParallel(BaseModel):
     """Specify observations and constraints for the optimization problem.
@@ -192,7 +203,8 @@ class DataBuilderParallel(BaseModel):
         # Save the span of the first data set
         span_loc = data_builder.space.span().copy()
 
-        # For the matrices, take Kronecker product with identity matrix
+        # Extend the data builder to the entire problem
+        # For the matrices, take the Kronecker product with identity matrix
         N = 1
         for dim in self.dim_parallel:
             N = N * len(df[dim].unique())

--- a/src/raking/experimental/data_parallel.py
+++ b/src/raking/experimental/data_parallel.py
@@ -54,6 +54,8 @@ class DataParallel(TypedDict):
         Matrix indicating how to sum the missing observations that are not constraints nor margins
         to get margins and constraints.
     mat_q : numpy.typing.NDArray
+        Matrix indicating how to get the missing observations once we know the raked margins and the constraints.
+        Should be equal to [mat_mc2^T mat_mc2]-1
     span : pandas.DataFrame
         Contains the values taken by the categorical variables in the raking problem (excluding aggregates).
     """

--- a/src/raking/experimental/linops/__init__.py
+++ b/src/raking/experimental/linops/__init__.py
@@ -1,0 +1,4 @@
+from .diag import Diag
+from .idblockdiag import IdBlockDiag
+
+__all__ = ["Diag", "IdBlockDiag"]

--- a/src/raking/experimental/linops/diag.py
+++ b/src/raking/experimental/linops/diag.py
@@ -1,0 +1,24 @@
+import numpy as np
+import numpy.typing as npt
+from scipy.sparse.linalg import LinearOperator
+
+from raking.special import div0
+
+
+class Diag(LinearOperator):
+    def __init__(self, diag: npt.NDArray) -> None:
+        self.diag = np.asarray(diag).ravel()
+        super().__init__(
+            dtype=self.diag.dtype,
+            shape=(self.diag.size, self.diag.size),
+        )
+
+    def _matvec(self, x: npt.NDArray) -> npt.NDArray:
+        return self.diag * np.asarray(x).ravel()
+
+    def _rmatvec(self, x: npt.NDArray) -> npt.NDArray:
+        return self.diag * np.asarray(x).ravel()
+
+    def solve(self, x: npt.NDArray, **kwargs) -> npt.NDArray:
+        x = np.asarray(x).ravel()
+        return div0(x, self.diag)

--- a/src/raking/experimental/linops/idblockdiag.py
+++ b/src/raking/experimental/linops/idblockdiag.py
@@ -1,0 +1,22 @@
+import numpy as np
+import numpy.typing as npt
+from scipy.sparse.linalg import LinearOperator, aslinearoperator
+
+from raking.linops.typing import LinearOperatorLike
+
+
+class IdBlockDiag(LinearOperator):
+    def __init__(self, op: LinearOperatorLike, n_blocks: int) -> None:
+        self.op = aslinearoperator(op)
+        self.n_blocks = n_blocks
+        super().__init__(
+            dtype=op.dtype, shape=(n_blocks * op.shape[0], n_blocks * op.shape[1])
+        )
+
+    def _matvec(self, x: npt.NDArray) -> npt.NDArray:
+        X = np.asarray(x).ravel().reshape(self.n_blocks, self.op.shape[1])
+        return (X @ self.op.T).ravel()
+
+    def _rmatvec(self, x: npt.NDArray) -> npt.NDArray:
+        X = np.asarray(x).ravel().reshape(self.n_blocks, self.op.shape[0])
+        return (X @ self.op).ravel()

--- a/src/raking/experimental/linops/typing.py
+++ b/src/raking/experimental/linops/typing.py
@@ -1,0 +1,18 @@
+from typing import Final, Protocol, Self, TypeAlias
+
+import numpy as np
+from scipy.sparse.linalg import LinearOperator
+
+
+class Matrix(Protocol):
+    ndim: Final[int] = 2
+    shape: tuple[int, int]
+    dtype: np.dtype
+
+    def __matmul__(self, x: np.ndarray | Self) -> np.ndarray | Self:
+        """Matrix multiplication"""
+
+
+LinearOperatorLike: TypeAlias = LinearOperator | Matrix
+
+__all__ = ["LinearOperatorLike"]

--- a/src/raking/experimental/optim.py
+++ b/src/raking/experimental/optim.py
@@ -1,0 +1,202 @@
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+@dataclass
+class NTResult:
+    """Newton's solver result.
+
+    Parameters
+    ----------
+    x
+        The solution of the optimization.
+    success
+        Whether or not the optimizer exited successfully.
+    fun
+        The objective function value.
+    grad
+        Gradient of the objective function.
+    hess
+        Hessian of the objective function.
+    niter
+        Number of iterations.
+
+    """
+
+    x: NDArray
+    success: bool
+    fun: float
+    grad: NDArray
+    hess: NDArray
+    niter: int
+
+
+class NTSolver:
+    """Newton's solver.
+
+    Parameters
+    ----------
+    fun
+        Optimization objective function
+    grad
+        Optimization gradient function
+    hess
+        Optimization hessian function
+
+    """
+
+    def __init__(self, fun: Callable, grad: Callable, hess: Callable):
+        self.fun = fun
+        self.grad = grad
+        self.hess = hess
+
+    def _update_params(
+        self,
+        x: list[NDArray],
+        dx: list[NDArray],
+        a_init: float = 1.0,
+        a_const: float = 0.01,
+        a_scale: float = 0.9,
+        a_lb: float = 1e-3,
+    ) -> tuple[float, list[NDArray]]:
+        """Update parameters with line search.
+
+        Parameters
+        ----------
+        x
+            A list a parameters, including x, s, and v, where s is the slackness
+            variable and v is the dual variable for the constraints.
+        dx
+            A list of direction for the parameters.
+        a_init
+            Initial step size, by default 1.0.
+        a_const
+            Constant for the line search condition, the larger the harder, by
+            default 0.01.
+        a_scale
+            Shrinkage factor for step size, by default 0.9.
+        a_lb
+            Lower bound of the step size when the step size is below this bound
+            the line search will be terminated.
+
+        Returns
+        -------
+        float
+            The step size in the given direction.
+
+        """
+        a = a_init
+        x_next = x + a * dx
+        g_next = self.grad(x_next)
+        gnorm_curr = np.max(np.abs(self.grad(x)))
+        gnorm_next = np.max(np.abs(g_next))
+
+        while gnorm_next > (1 - a_const * a) * gnorm_curr:
+            if a * a_scale < a_lb:
+                raise ValueError(f"step size reach lower bound {a_lb}")
+            a *= a_scale
+            x_next = x + a * dx
+            g_next = self.grad(x_next)
+            gnorm_next = np.max(np.abs(g_next))
+        return a, x_next
+
+    def minimize(
+        self,
+        x0: NDArray,
+        xtol: float = 1e-8,
+        gtol: float = 1e-8,
+        max_iter: int = 100,
+        a_init: float = 1.0,
+        a_const: float = 0.01,
+        a_scale: float = 0.9,
+        a_lb: float = 1e-3,
+        verbose: bool = False,
+        mat_solve_method: str = "",
+        mat_solve_options: dict | None = None,
+    ) -> NDArray:
+        """Minimize optimization objective over constraints.
+
+        Parameters
+        ----------
+        x0
+            Initial guess for the solution.
+        xtol
+            Tolerance for the differences in `x`, by default 1e-8.
+        gtol
+            Tolerance for the KKT system, by default 1e-8.
+        max_iter
+            Maximum number of iterations, by default 100.
+        a_init
+            Initial step size, by default 1.0.
+        a_const
+            Constant for the line search condition, the larger the harder, by
+            default 0.01.
+        a_scale
+            Shrinkage factor for step size, by default 0.9.
+        a_lb
+            Lower bound of the step size when the step size is below this bound
+            the line search will be terminated.
+        verbose
+            Indicator of if print out convergence history, by default False
+        mat_solve_method
+            Method to solve the linear system, by default "".
+        mat_solve_options
+            Options for the linear system solver, by default None.
+
+        Returns
+        -------
+        NTResult
+            Result of the solver.
+
+        """
+
+        # initialize the parameters
+        x = x0.copy()
+        mat_solve_options = mat_solve_options or {}
+
+        g = self.grad(x)
+        gnorm = np.max(np.abs(g))
+        xdiff = 1.0
+        step = 1.0
+        niter = 0
+        success = gnorm <= gtol
+
+        if verbose:
+            fun = self.fun(x)
+            print(f"{type(self).__name__}:")
+            print(f"{niter=:3d}, {fun=:.2e}, {gnorm=:.2e}, {xdiff=:.2e}, {step=:.2e}")
+
+        while (not success) and (niter < max_iter):
+            niter += 1
+
+            # compute all directions
+            dx = -self.hess(x).solve(g, method=mat_solve_method, **mat_solve_options)
+
+            # get step size
+            step, x = self._update_params(x, dx, a_init, a_const, a_scale, a_lb)
+
+            # update f and gnorm
+            g = self.grad(x)
+            gnorm = np.max(np.abs(g))
+            xdiff = step * np.max(np.abs(dx))
+
+            if verbose:
+                fun = self.fun(x)
+                print(
+                    f"{niter=:3d}, {fun=:.2e}, {gnorm=:.2e}, {xdiff=:.2e}, {step=:.2e}"
+                )
+            success = gnorm <= gtol or xdiff <= xtol
+
+        result = NTResult(
+            x=x,
+            success=success,
+            fun=self.fun(x),
+            grad=self.grad(x),
+            hess=self.hess(x),
+            niter=niter,
+        )
+
+        return result

--- a/src/raking/experimental/solver.py
+++ b/src/raking/experimental/solver.py
@@ -43,6 +43,7 @@ class DualSolver:
         DualSolver
             DualSolver instance.
         """
+        self.distance = distance
         self.fun = distance_map[distance](
             y=data["vec_y"],
             w=data["vec_w"],
@@ -116,6 +117,7 @@ class DualSolver:
         x : numpy.typing.NDArray
             Solution of the primal problem.
         """
+        # size_p is the number of non-missing observations that are not margins and not constraints
         size_p = self.data["vec_p"].sum()
 
         vec_g = self.fun(self.mat_o @ z, order=1)
@@ -129,6 +131,7 @@ class DualSolver:
         x[self.data["vec_p"]] = x1
         x[~self.data["vec_p"]] = x2
         return x
+
 
     def solve(
         self,
@@ -157,6 +160,16 @@ class DualSolver:
             The soln column contains the value of the raked observations.
         """
         if x0 is None:
+#            fun = distance_map[distance](
+#                y=data["vec_y"],
+#                w=data["vec_w"],
+#                l=data["vec_l"],
+#                u=data["vec_u"],
+#            ).fun
+#            grad = self.mat_o.T @ fun(self.mat_o @ self.data["vec_init"], order=1)
+#            x0 = sps.linalg.cg(self.mat_o.T, - grad)[0]
+#
+#
             x0 = np.zeros(self.mat_o.shape[1])
 
         constraints = None
@@ -208,8 +221,13 @@ class PrimalSolver:
     fun : raking.experimental.distance.Distance
         Distance between observations and raked values.
     mat_o : scipy.sparse.csr_matrix
+        Matrix to transform the unknown raked values corresponding to missing and non-missing
+        observations that are margins or non-margins, and compare them to the available observations.
     mat_c : scipy.sparse.csr_matrix
+        Matrix to sum the unknown raked values corresponding to missing and non-missing
+        observations that are margins or non-margins to get the constraints.
     vec_c : np.array
+        Contains the constraints.
     result : scipy.optimize.OptimizeResult
         Contains info on the solution and the convergence of the optimization problem.
     """
@@ -238,8 +256,12 @@ class PrimalSolver:
         ).fun
 
         self.data = data
+        # size_v is the number of observations (missing and non-missing) that are not margins and not constraints
+        # size_r is the number of non-missing observations that are not margins and not constraints
         size_v, size_r = data["vec_p"].size, data["vec_p"].sum()
 
+        # Projection matrix:
+        # mat_s [missing + non-missing, non-constraints, non-margins obs] = [non-missing, non-constraints, non-margins obs]
         mat_s = sps.csr_matrix(
             (
                 np.ones(size_r, dtype=int),
@@ -251,7 +273,10 @@ class PrimalSolver:
             shape=(size_r, size_v),
         )
 
+        # mat_o is used to compute the distance between unknown raked values and non-missing, non-constraints observations
         self.mat_o = sps.csr_matrix(sps.vstack([mat_s, data["mat_m"]]))
+        # mat_c is used to take the missing and non-missing, non-margins, non constraints unknowned raked values
+        # and transform them into the constraints that are stored in vec_c
         self.mat_c = data["mat_c"]
         self.vec_c = data["vec_b"]
         self.result = None
@@ -326,6 +351,8 @@ class PrimalSolver:
             The soln column contains the value of the raked observations.
         """
         if x0 is None:
+            # Choose x0 = y or 0 if missing
+            # x0 = self.data["vec_init"]
             x0 = np.zeros(self.mat_o.shape[1])
 
         constraints = None

--- a/src/raking/experimental/solver.py
+++ b/src/raking/experimental/solver.py
@@ -120,13 +120,20 @@ class DualSolver:
         # size_p is the number of non-missing observations that are not margins and not constraints
         size_p = self.data["vec_p"].sum()
 
+        # The inverse of the gradient of the distance function is equal to the gradient of the conjugate
         vec_g = self.fun(self.mat_o @ z, order=1)
         x1 = vec_g[:size_p]
 
+        # vec_s contains the raked margins and the constraints
         vec_s = np.hstack([vec_g[size_p:], self.data["vec_b"]])
+        # We remove from the raked margins and constraints the part computed with the raked non-missing observations.
+        # vec_s now contains the part computed with the unknown raked missing observations
         vec_s = vec_s - self.data["mat_mc1"].dot(x1)
+        # We now have vec_s = mat_mc2 x2 => x2 = [mat_mc2^T mat_mc2]-1 (mat_mc2^T vec_s)
         x2 = self.data["mat_q"] @ (self.data["mat_mc2"].T @ vec_s)
 
+        # We assign the raked non-missing observations and the raked missing observations
+        # in the output vector in the same order as the input data
         x = np.zeros_like(self.data["vec_p"], dtype=float)
         x[self.data["vec_p"]] = x1
         x[~self.data["vec_p"]] = x2
@@ -160,17 +167,29 @@ class DualSolver:
             The soln column contains the value of the raked observations.
         """
         if x0 is None:
-#            fun = distance_map[distance](
-#                y=data["vec_y"],
-#                w=data["vec_w"],
-#                l=data["vec_l"],
-#                u=data["vec_u"],
-#            ).fun
-#            grad = self.mat_o.T @ fun(self.mat_o @ self.data["vec_init"], order=1)
-#            x0 = sps.linalg.cg(self.mat_o.T, - grad)[0]
-#
-#
-            x0 = np.zeros(self.mat_o.shape[1])
+            # We need the gradient of the initial function (not the conjugate) here
+            fun = distance_map[self.distance](
+                y=self.data["vec_y"],
+                w=self.data["vec_w"],
+                l=self.data["vec_l"],
+                u=self.data["vec_u"],
+            ).fun
+            # We also need the matrix used in the objective of the primal problem
+            size_v, size_r = self.data["vec_p"].size, self.data["vec_p"].sum()
+            mat_s = sps.csr_matrix(
+                (
+                    np.ones(size_r, dtype=int),
+                    (
+                        np.arange(size_r, dtype=int),
+                        np.arange(size_v, dtype=int)[self.data["vec_p"]],
+                    ),
+                ),
+                shape=(size_r, size_v),
+            )
+            mat_o = sps.csr_matrix(sps.vstack([mat_s, self.data["mat_m"]]))
+            grad = fun(mat_o @ self.data["vec_init"], order=1)
+            x0 = sps.linalg.lsqr(self.mat_o, grad)[0]
+            # x0 = np.zeros(self.mat_o.shape[1])
 
         constraints = None
         if self.vec_c.size > 0:
@@ -260,8 +279,8 @@ class PrimalSolver:
         # size_r is the number of non-missing observations that are not margins and not constraints
         size_v, size_r = data["vec_p"].size, data["vec_p"].sum()
 
-        # Projection matrix:
-        # mat_s [missing + non-missing, non-constraints, non-margins obs] = [non-missing, non-constraints, non-margins obs]
+        # mat_s [missing + non-missing, non-constraints, non-margins obs] =
+        # [non-missing, non-constraints, non-margins obs]
         mat_s = sps.csr_matrix(
             (
                 np.ones(size_r, dtype=int),
@@ -273,7 +292,8 @@ class PrimalSolver:
             shape=(size_r, size_v),
         )
 
-        # mat_o is used to compute the distance between unknown raked values and non-missing, non-constraints observations
+        # mat_o is used to compute the distance between unknown raked values
+        # and non-missing, non-constraints observations
         self.mat_o = sps.csr_matrix(sps.vstack([mat_s, data["mat_m"]]))
         # mat_c is used to take the missing and non-missing, non-margins, non constraints unknowned raked values
         # and transform them into the constraints that are stored in vec_c
@@ -352,8 +372,8 @@ class PrimalSolver:
         """
         if x0 is None:
             # Choose x0 = y or 0 if missing
-            # x0 = self.data["vec_init"]
-            x0 = np.zeros(self.mat_o.shape[1])
+            x0 = self.data["vec_init"]
+            # x0 = np.zeros(self.mat_o.shape[1])
 
         constraints = None
         if self.vec_c.size > 0:

--- a/src/raking/experimental/solver.py
+++ b/src/raking/experimental/solver.py
@@ -370,7 +370,6 @@ class PrimalSolver:
             The soln column contains the value of the raked observations.
         """
         if x0 is None:
-            # Choose x0 = y or 0 if missing
             x0 = self.data["vec_init"]
             # x0 = np.zeros(self.mat_o.shape[1])
 

--- a/src/raking/experimental/solver_parallel.py
+++ b/src/raking/experimental/solver_parallel.py
@@ -5,9 +5,31 @@ import numpy.typing as npt
 import pandas as pd
 import scipy.sparse as sps
 from scipy.optimize import LinearConstraint, minimize
+from scipy.sparse.linalg import LinearOperator
 
 from raking.experimental.data_parallel import DataParallel
 from raking.experimental.distance import distance_map
+from raking.experimental.optim import NTResult, NTSolver
+from raking.experimental.special import div0, log0
+
+
+class Hessian_operator(LinearOperator):
+    """
+    Transform the Hessian matrix into linear operator.
+    """
+
+    def __init__(self, hessian: npt.NDArray) -> None:
+        self.hessian = hessian
+        super().__init__(
+            dtype=self.hessian.dtype,
+            shape=self.hessian.shape,
+        )
+
+    def _matvec(self, x: npt.NDArray) -> npt.NDArray:
+        return self.hessian @ x
+
+    def solve(self, x: npt.NDArray, **kwargs) -> npt.NDArray:
+        return sps.linalg.spsolve(self.hessian, x)
 
 
 class DualSolverParallel:
@@ -23,7 +45,7 @@ class DualSolverParallel:
     mat_c : scipy.sparse.csr_matrix
     vec_o : np.array
     vec_c : np.array
-    result : scipy.optimize.OptimizeResult
+    result : scipy.optimize.OptimizeResult or NTResult
         Contains info on the solution and the convergence of the optimization problem.
     """
 
@@ -99,7 +121,12 @@ class DualSolverParallel:
         Hessian of the objective function (scipy.sparse.csc_matrix).
         """
         d2 = self.fun(self.mat_o @ x, order=2)
-        return (self.mat_o.T.multiply(d2)) @ self.mat_o
+        hessian_matrix = (self.mat_o.T.multiply(d2)) @ self.mat_o
+        if self.vec_c.size == 0:
+            return Hessian_operator(hessian_matrix)
+        else:
+            return hessian_matrix
+    
 
     def dual_to_primal(self, z: npt.NDArray) -> npt.NDArray:
         """Transforms dual solution into primal solution.
@@ -137,21 +164,37 @@ class DualSolverParallel:
         x[~self.data["vec_p"]] = x2
         return x
 
+    def get_x0(self, x0: npt.NDArray | None) -> npt.NDArray:
+        if x0 is None:
+            # We only implement the initialization for entropic distance
+            # as we have to deal with 0s in the observations and cannot use directly the distance map
+            if self.distance != "entropic":
+                x0 = np.zeros(self.mat_o.shape[1])
+            else:
+                # We need the matrix used in the objective of the primal problem
+                # to transform initial guess for raked values into initial guess for the dual.
+                mat_o = self.data["mat_o_primal"]
+                # We compute the gradient of the entropic distance
+                # while avoiding taking logarithms of 0s
+                grad = log0(div0(mat_o @ self.data["vec_init"], self.data["vec_y"]))
+                # Taking the gradient of the Lagrangian, we have:
+                # nabla f(zeta0,y) + (mat_m I \\ mat_c 0)^T lambda0
+                x0 = sps.linalg.lsqr(self.mat_o, grad)[0]
+
+        return x0
+
     def solve(
         self,
         x0: npt.NDArray | None = None,
-        method: str | None = None,
         tol: float = 1.0e-11,
         options: dict | None = None,
     ) -> pd.DataFrame:
-        """Solve the dual problem using scipy.optimize.minimize.
+        """Solve the dual problem using scipy.optimize.minimize or the MSCA solver.
 
         Parameters
         ----------
         x0 : numpy.typing.NDArray
             Initial guess for the dual.
-        method: str
-            Optimization method. See scipy.optimize.minimize documentation for possible options.
         tol: float
             Tolerance for termination. See scipy.optimize.minimize documentation for details.
         options : dict
@@ -163,55 +206,34 @@ class DualSolverParallel:
             Columns contain the categorical variables in the initial dataset (without the margins).
             The soln column contains the value of the raked observations.
         """
-        if x0 is None:
-            # We need the gradient of the initial function (not the conjugate) here
-            fun = distance_map[self.distance](
-                y=self.data["vec_y"],
-                w=self.data["vec_w"],
-                l=self.data["vec_l"],
-                u=self.data["vec_u"],
-            ).fun
-            # We also need the matrix used in the objective of the primal problem
-            grad = fun(
-                self.data["mat_o_primal"] @ self.data["vec_init"], order=1
-            )
-            x0 = sps.linalg.lsqr(self.mat_o, grad)[0]
-            # x0 = np.zeros(self.mat_o.shape[1])
+        # Initialization
+        x0 = self.get_x0(x0)
 
-        constraints = None
-        if self.vec_c.size > 0:
-            constraints = [LinearConstraint(self.mat_c, self.vec_c, self.vec_c)]
 
-        if method is None:
-            method = "L-BFGS-B" if self.vec_c.size == 0 else "trust-constr"
-
-        if options == None:
-            if method == "L-BFGS-B":
-                options = {"ftol": 1.0e-11, "gtol": 1.0e-11}
-            if method == "trust-constr":
-                options = {"gtol": 1.0e-11, "xtol": 1.0e-11}
-
-        if method == "L-BFGS-B":
-            self.result = minimize(
-                self.objective,
-                x0,
-                method=method,
-                jac=self.gradient,
-                tol=tol,
-                options=options,
-            )
+        if self.vec_c.size == 0:
+            if options is None:
+                options = {}
+            interface = {
+                "fun": self.objective,
+                "grad": self.gradient,
+                "hess": self.hessian,
+            }
+            optimizer = NTSolver(**interface)
+            self.result = optimizer.minimize(x0=x0, **options)
         else:
+            constraints = [LinearConstraint(self.mat_c, self.vec_c, self.vec_c)]
+            if options == None:
+                options = {"gtol": 1.0e-11, "xtol": 1.0e-11}
             self.result = minimize(
                 self.objective,
                 x0,
-                method=method,
+                method="trust-constr",
                 jac=self.gradient,
                 hess=self.hessian,
                 constraints=constraints,
                 tol=tol,
                 options=options,
             )
-
         soln = self.data["span"].copy()
         soln["soln"] = self.dual_to_primal(self.result.x)
         return soln

--- a/src/raking/experimental/solver_parallel.py
+++ b/src/raking/experimental/solver_parallel.py
@@ -6,11 +6,11 @@ import pandas as pd
 import scipy.sparse as sps
 from scipy.optimize import LinearConstraint, minimize
 
-from raking.experimental.data import Data
+from raking.experimental.data_parallel import DataParallel
 from raking.experimental.distance import distance_map
 
 
-class DualSolver:
+class DualSolverParallel:
     """Solver for the dual problem.
 
     Parameters
@@ -27,7 +27,7 @@ class DualSolver:
         Contains info on the solution and the convergence of the optimization problem.
     """
 
-    def __init__(self, distance: str, data: Data) -> None:
+    def __init__(self, distance: str, data: DataParallel) -> None:
         """Create DualSolver instance.
 
         Parameters
@@ -35,7 +35,7 @@ class DualSolver:
         distance : str
             Distance between observations and raked values.
             Currently, only chi2, entropic and logistic are implemented.
-        data: raking.experimental.data.Data
+        data: raking.experimental.data_parallel.DataParallel
             Contains observations data and constraints for the optimization problem.
 
         Returns
@@ -52,13 +52,10 @@ class DualSolver:
         ).conjugate_fun
 
         self.data = data
-        size_m, size_c = data["mat_m"].shape[0], data["mat_c"].shape[0]
-        self.mat_o = sps.csr_matrix(
-            sps.vstack([-data["mat_mc1"].T, sps.eye(size_m, n=size_m + size_c)])
-        )
-        self.vec_o = np.hstack([np.zeros(size_m), data["vec_b"]])
-        self.mat_c = data["mat_mc2"].T
-        self.vec_c = np.zeros(self.mat_c.shape[0])
+        self.mat_o = data["mat_o_dual"]
+        self.vec_o = data["vec_o_dual"]
+        self.mat_c = data["mat_c_dual"]
+        self.vec_c = data["vec_c_dual"]
         self.result = None
 
     def objective(self, x: npt.NDArray) -> float:
@@ -117,23 +114,24 @@ class DualSolver:
         x : numpy.typing.NDArray
             Solution of the primal problem.
         """
-        # size_p is the number of non-missing observations that are not margins and not constraints
-        size_p = self.data["vec_p"].sum()
-
-        # The inverse of the gradient of the distance function is equal to the gradient of the conjugate
+        N = self.data["N"]
+        size_p = int(self.data["vec_p"].sum() / N)
         vec_g = self.fun(self.mat_o @ z, order=1)
-        x1 = vec_g[:size_p]
+        size_g = int(vec_g.size / N)
 
-        # vec_s contains the raked margins and the constraints
-        vec_s = np.hstack([vec_g[size_p:], self.data["vec_b"]])
-        # We remove from the raked margins and constraints the part computed with the raked non-missing observations.
-        # vec_s now contains the part computed with the unknown raked missing observations
+        x1 = np.ravel(np.reshape(vec_g, (size_g, N), "F")[:size_p, :], "F")
+        size_b = int(self.data["vec_b"].size / N)
+        vec_s = np.ravel(
+            np.vstack(
+                [
+                    np.reshape(vec_g, (size_g, N), "F")[size_p:, :],
+                    np.reshape(self.data["vec_b"], (size_b, N), "F"),
+                ]
+            ),
+            "F",
+        )
         vec_s = vec_s - self.data["mat_mc1"].dot(x1)
-        # We now have vec_s = mat_mc2 x2 => x2 = [mat_mc2^T mat_mc2]-1 (mat_mc2^T vec_s)
         x2 = self.data["mat_q"] @ (self.data["mat_mc2"].T @ vec_s)
-
-        # We assign the raked non-missing observations and the raked missing observations
-        # in the output vector in the same order as the input data
         x = np.zeros_like(self.data["vec_p"], dtype=float)
         x[self.data["vec_p"]] = x1
         x[~self.data["vec_p"]] = x2
@@ -174,19 +172,9 @@ class DualSolver:
                 u=self.data["vec_u"],
             ).fun
             # We also need the matrix used in the objective of the primal problem
-            size_v, size_r = self.data["vec_p"].size, self.data["vec_p"].sum()
-            mat_s = sps.csr_matrix(
-                (
-                    np.ones(size_r, dtype=int),
-                    (
-                        np.arange(size_r, dtype=int),
-                        np.arange(size_v, dtype=int)[self.data["vec_p"]],
-                    ),
-                ),
-                shape=(size_r, size_v),
+            grad = fun(
+                self.data["mat_o_primal"] @ self.data["vec_init"], order=1
             )
-            mat_o = sps.csr_matrix(sps.vstack([mat_s, self.data["mat_m"]]))
-            grad = fun(mat_o @ self.data["vec_init"], order=1)
             x0 = sps.linalg.lsqr(self.mat_o, grad)[0]
             # x0 = np.zeros(self.mat_o.shape[1])
 
@@ -229,12 +217,12 @@ class DualSolver:
         return soln
 
 
-class PrimalSolver:
+class PrimalSolverParallel:
     """Solver for the primal problem.
 
     Parameters
     ----------
-    data : raking.experimental.data.Data
+    data : raking.experimental.data_parallel.DataParallel
         Contains observations data and constraints for the optimization problem.
     fun : raking.experimental.distance.Distance
         Distance between observations and raked values.
@@ -250,7 +238,7 @@ class PrimalSolver:
         Contains info on the solution and the convergence of the optimization problem.
     """
 
-    def __init__(self, distance: str, data: Data) -> None:
+    def __init__(self, distance: str, data: DataParallel) -> None:
         """Create PrimalSolver instance.
 
         Parameters
@@ -274,30 +262,9 @@ class PrimalSolver:
         ).fun
 
         self.data = data
-        # size_v is the number of observations (missing and non-missing) that are not margins and not constraints
-        # size_r is the number of non-missing observations that are not margins and not constraints
-        size_v, size_r = data["vec_p"].size, data["vec_p"].sum()
-
-        # mat_s [missing + non-missing, non-constraints, non-margins obs] =
-        # [non-missing, non-constraints, non-margins obs]
-        mat_s = sps.csr_matrix(
-            (
-                np.ones(size_r, dtype=int),
-                (
-                    np.arange(size_r, dtype=int),
-                    np.arange(size_v, dtype=int)[data["vec_p"]],
-                ),
-            ),
-            shape=(size_r, size_v),
-        )
-
-        # mat_o is used to compute the distance between unknown raked values
-        # and non-missing, non-constraints observations
-        self.mat_o = sps.csr_matrix(sps.vstack([mat_s, data["mat_m"]]))
-        # mat_c is used to take the missing and non-missing, non-margins, non constraints unknowned raked values
-        # and transform them into the constraints that are stored in vec_c
-        self.mat_c = data["mat_c"]
-        self.vec_c = data["vec_b"]
+        self.mat_o = data["mat_o_primal"]
+        self.mat_c = data["mat_c_primal"]
+        self.vec_c = data["vec_c_primal"]
         self.result = None
 
     def objective(self, x: npt.NDArray) -> float:

--- a/src/raking/experimental/solver_parallel.py
+++ b/src/raking/experimental/solver_parallel.py
@@ -13,7 +13,7 @@ from raking.experimental.optim import NTResult, NTSolver
 from raking.experimental.special import div0, log0
 
 
-class Hessian_operator(LinearOperator):
+class HessianOperator(LinearOperator):
     """
     Transform the Hessian matrix into linear operator.
     """
@@ -123,7 +123,7 @@ class DualSolverParallel:
         d2 = self.fun(self.mat_o @ x, order=2)
         hessian_matrix = (self.mat_o.T.multiply(d2)) @ self.mat_o
         if self.vec_c.size == 0:
-            return Hessian_operator(hessian_matrix)
+            return HessianOperator(hessian_matrix)
         else:
             return hessian_matrix
     
@@ -359,7 +359,6 @@ class PrimalSolverParallel:
             The soln column contains the value of the raked observations.
         """
         if x0 is None:
-            # Choose x0 = y or 0 if missing
             x0 = self.data["vec_init"]
             # x0 = np.zeros(self.mat_o.shape[1])
 

--- a/src/raking/experimental/special.py
+++ b/src/raking/experimental/special.py
@@ -1,0 +1,101 @@
+import numpy as np
+import numpy.typing as npt
+
+
+def log0(x: npt.NDArray) -> npt.NDArray:
+    """Compute the element-wise logarithm of an array, treating log(0) as 0.
+
+    Parameters
+    ----------
+    x
+        Input array.
+
+    Returns
+    -------
+    npt.NDArray
+        Element-wise logarithm of the input array, with log(0) treated as 0.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> from raking_codcorrect.special import log0
+    >>> x = np.array([1.0, 0.0])
+    >>> log0(x)
+    array([0., 0.])
+
+    """
+    index = x != 0.0
+    out = np.zeros_like(x)
+    out[index] = np.log(x[index])
+    return out
+
+
+def div0(numerator: npt.NDArray, denominator: npt.NDArray) -> npt.NDArray:
+    """Compute the element-wise division of two arrays, treating 0/any as 0.
+
+    Parameters
+    ----------
+    numerator
+        Numerator array.
+    denominator
+        Denominator array.
+
+    Returns
+    -------
+    npt.NDArray
+        Element-wise division of the numerator by the denominator, with 0/any
+        treated as 0.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> from raking_codcorrect.special import div0
+    >>> numerator = np.array([1.0, 0.0, 0.0])
+    >>> denominator = np.array([2.0, 0.0, np.nan])
+    >>> div0(numerator, denominator)
+    array([0.5, 0. , 0.])
+
+    """
+    index = numerator != 0
+    out = np.zeros_like(numerator)
+    if not np.isfinite(denominator[index]).all():
+        raise ValueError(
+            "Denominator has non-finite values where numerator is non-zero"
+        )
+    if not (denominator[index] != 0).all():
+        raise ValueError("Denominator has zero values where numerator is non-zero")
+    out[index] = numerator[index] / denominator[index]
+    return out
+
+
+def mul0(left: npt.NDArray, right: npt.NDArray) -> npt.NDArray:
+    """Compute the element-wise multiplication of two arrays, treating 0*any or
+    any*0 as 0.
+
+    Parameters
+    ----------
+    left
+        Left array.
+    right
+        Right array.
+
+    Returns
+    -------
+    npt.NDArray
+        Element-wise multiplication of the two input arrays, with 0*any or any*0
+        treated as 0.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> from raking_codcorrect.special import mul0
+    >>> left = np.array([1.0, np.nan, 0.0])
+    >>> right = np.array([2.0, 0.0, np.nan])
+    >>> mul0(left, right)
+    array([2., 0., 0.])
+
+    """
+    index = (left != 0) & (right != 0)
+    out = np.zeros_like(left)
+    out[index] = left[index] * right[index]
+    return out

--- a/src/raking/formatting_methods.py
+++ b/src/raking/formatting_methods.py
@@ -875,9 +875,9 @@ def format_data_USHD(
     assert isinstance(df_obs, pd.DataFrame), (
         "The observations should be a pandas data frame."
     )
-#    assert len(df_obs) >= 18, (
-#        "There should be at least 18 data points for the observations."
-#    )
+    #    assert len(df_obs) >= 18, (
+    #        "There should be at least 18 data points for the observations."
+    #    )
     assert len(df_obs) >= 9, (
         "There should be at least 9 data points for the observations."
     )
@@ -1090,9 +1090,9 @@ def format_data_USHD_lower(
     assert isinstance(df_obs, pd.DataFrame), (
         "The observations should be a pandas data frame."
     )
-#    assert len(df_obs) >= 12, (
-#        "There should be at least 12 data points for the observations."
-#    )
+    #    assert len(df_obs) >= 12, (
+    #        "There should be at least 12 data points for the observations."
+    #    )
     assert len(df_obs) >= 6, (
         "There should be at least 6 data points for the observations."
     )
@@ -1107,9 +1107,9 @@ def format_data_USHD_lower(
     assert isinstance(df_margins_county, pd.DataFrame), (
         "The county margins should be a pandas data frame."
     )
-#    assert len(df_margins_county) >= 2, (
-#        "There should be at least 2 data points for the county margins."
-#    )
+    #    assert len(df_margins_county) >= 2, (
+    #        "There should be at least 2 data points for the county margins."
+    #    )
     assert len(df_margins_county) >= 1, (
         "There should be at least 1 data point for the county margins."
     )
@@ -1117,9 +1117,9 @@ def format_data_USHD_lower(
     assert isinstance(df_margins_all_causes, pd.DataFrame), (
         "The all causes margins should be a pandas data frame."
     )
-#    assert len(df_margins_all_causes) >= 4, (
-#        "There should be at least 4 data points for the all causes margins."
-#    )
+    #    assert len(df_margins_all_causes) >= 4, (
+    #        "There should be at least 4 data points for the all causes margins."
+    #    )
     assert len(df_margins_all_causes) >= 2, (
         "There should be at least 2 data points for the all causes margins."
     )

--- a/src/raking/raking_methods.py
+++ b/src/raking/raking_methods.py
@@ -336,8 +336,7 @@ def raking_entropic_parallel(
     gamma: float = 1.0e-4,
     max_iter: int = 500,
 ) -> tuple[np.ndarray, np.ndarray, int]:
-    """Raking using the entropic distance f(beta, y) = beta log(beta/y) + y - beta.
-    """
+    """Raking using the entropic distance f(beta, y) = beta log(beta/y) + y - beta."""
     # Raking weights
     if q is None:
         q = np.ones(len(y))

--- a/tests/test_exp_parallel_1D.py
+++ b/tests/test_exp_parallel_1D.py
@@ -4,6 +4,7 @@ import pandas as pd
 from raking.experimental import DataBuilder
 from raking.experimental import DataBuilderParallel
 from raking.experimental import DualSolver
+from raking.experimental import DualSolverParallel
 
 
 def test_parallel(example_1D_draws):
@@ -14,6 +15,8 @@ def test_parallel(example_1D_draws):
     df_margin["weights"] = np.inf
     df_margin.rename(columns={"value_agg_over_var1": "value"}, inplace=True)
     df = pd.concat([df_obs, df_margin])
+
+    df = df.loc[df.draws < 10.5]
 
     # Loop on the draws
     draws = df.draws.unique().tolist()
@@ -31,24 +34,37 @@ def test_parallel(example_1D_draws):
     df_raked = pd.concat(df_raked)
 
     # Check the results for the loop on the draws
-    sum_over_var1 = df_raked.groupby(["draws"]).agg({"soln": "sum"}). \
-        merge(df.loc[df["var1"]==-1], on=["draws"], how="inner")
-    assert np.allclose(sum_over_var1["soln"].to_numpy(), sum_over_var1["value"].to_numpy()), ("For the loop, the raked values do not sum to the margin.")
-           
+    sum_over_var1 = (
+        df_raked.groupby(["draws"])
+        .agg({"soln": "sum"})
+        .merge(df.loc[df["var1"] == -1], on=["draws"], how="inner")
+    )
+    assert np.allclose(
+        sum_over_var1["soln"].to_numpy(), sum_over_var1["value"].to_numpy()
+    ), "For the loop, the raked values do not sum to the margin."
+
     # Use parallelization
     # The matrix in the objective of the dual has shape (3000, 1000) and full rank.
     # The solver converges correctly.
     data_builder = DataBuilderParallel(
-        dim_specs={"var1": -1}, dim_parallel=["draws"], value="value", weights="weights"
+        dim_specs={"var1": -1},
+        dim_parallel=["draws"],
+        value="value",
+        weights="weights",
     )
     data = data_builder.build(df)
-    solver = DualSolver(distance="entropic", data=data)
+    solver = DualSolverParallel(distance="entropic", data=data)
     df_raked_parallel = solver.solve()
 
     # Check the results for the parallelization
-    sum_over_var1 = df_raked_parallel.groupby(["draws"]).agg({"soln": "sum"}). \
-        merge(df.loc[df["var1"]==-1], on=["draws"], how="inner")
-    assert np.allclose(sum_over_var1["soln"].to_numpy(), sum_over_var1["value"].to_numpy()), ("For the parallelization, the raked values do not sum to the margin.")
+    sum_over_var1 = (
+        df_raked_parallel.groupby(["draws"])
+        .agg({"soln": "sum"})
+        .merge(df.loc[df["var1"] == -1], on=["draws"], how="inner")
+    )
+    assert np.allclose(
+        sum_over_var1["soln"].to_numpy(), sum_over_var1["value"].to_numpy()
+    ), "For the parallelization, the raked values do not sum to the margin."
 
     # Compare results
     df_both = pd.merge(
@@ -57,8 +73,6 @@ def test_parallel(example_1D_draws):
         on=["var1", "draws"],
         how="inner",
     )
-    assert np.allclose(
-        df_both["soln_x"],
-        df_both["soln_y"]
-    ), "The two rakings must give the same results."
-
+    assert np.allclose(df_both["soln_x"], df_both["soln_y"]), (
+        "The two rakings must give the same results."
+    )

--- a/tests/test_exp_parallel_1D.py
+++ b/tests/test_exp_parallel_1D.py
@@ -36,6 +36,8 @@ def test_parallel(example_1D_draws):
     assert np.allclose(sum_over_var1["soln"].to_numpy(), sum_over_var1["value"].to_numpy()), ("For the loop, the raked values do not sum to the margin.")
            
     # Use parallelization
+    # The matrix in the objective of the dual has shape (3000, 1000) and full rank.
+    # The solver converges correctly.
     data_builder = DataBuilderParallel(
         dim_specs={"var1": -1}, dim_parallel=["draws"], value="value", weights="weights"
     )

--- a/tests/test_exp_parallel_1D.py
+++ b/tests/test_exp_parallel_1D.py
@@ -1,0 +1,62 @@
+import pytest
+import numpy as np
+import pandas as pd
+from raking.experimental import DataBuilder
+from raking.experimental import DataBuilderParallel
+from raking.experimental import DualSolver
+
+
+def test_parallel(example_1D_draws):
+    df_obs = example_1D_draws.df_obs
+    df_margin = example_1D_draws.df_margin
+    df_obs["weights"] = 1.0
+    df_margin["var1"] = -1
+    df_margin["weights"] = np.inf
+    df_margin.rename(columns={"value_agg_over_var1": "value"}, inplace=True)
+    df = pd.concat([df_obs, df_margin])
+
+    # Loop on the draws
+    draws = df.draws.unique().tolist()
+    df_raked = []
+    for draw in draws:
+        df_loc = df.loc[df.draws == draw]
+        data_builder = DataBuilder(
+            dim_specs={"var1": -1}, value="value", weights="weights"
+        )
+        data = data_builder.build(df_loc)
+        solver = DualSolver(distance="entropic", data=data)
+        soln = solver.solve()
+        soln["draws"] = draw
+        df_raked.append(soln)
+    df_raked = pd.concat(df_raked)
+
+    # Check the results for the loop on the draws
+    sum_over_var1 = df_raked.groupby(["draws"]).agg({"soln": "sum"}). \
+        merge(df.loc[df["var1"]==-1], on=["draws"], how="inner")
+    assert np.allclose(sum_over_var1["soln"].to_numpy(), sum_over_var1["value"].to_numpy()), ("For the loop, the raked values do not sum to the margin.")
+           
+    # Use parallelization
+    data_builder = DataBuilderParallel(
+        dim_specs={"var1": -1}, dim_parallel=["draws"], value="value", weights="weights"
+    )
+    data = data_builder.build(df)
+    solver = DualSolver(distance="entropic", data=data)
+    df_raked_parallel = solver.solve()
+
+    # Check the results for the parallelization
+    sum_over_var1 = df_raked_parallel.groupby(["draws"]).agg({"soln": "sum"}). \
+        merge(df.loc[df["var1"]==-1], on=["draws"], how="inner")
+    assert np.allclose(sum_over_var1["soln"].to_numpy(), sum_over_var1["value"].to_numpy()), ("For the parallelization, the raked values do not sum to the margin.")
+
+    # Compare results
+    df_both = pd.merge(
+        df_raked,
+        df_raked_parallel,
+        on=["var1", "draws"],
+        how="inner",
+    )
+    assert np.allclose(
+        df_both["soln_x"],
+        df_both["soln_y"]
+    ), "The two rakings must give the same results."
+

--- a/tests/test_exp_parallel_1D.py
+++ b/tests/test_exp_parallel_1D.py
@@ -16,8 +16,6 @@ def test_parallel(example_1D_draws):
     df_margin.rename(columns={"value_agg_over_var1": "value"}, inplace=True)
     df = pd.concat([df_obs, df_margin])
 
-    df = df.loc[df.draws < 10.5]
-
     # Loop on the draws
     draws = df.draws.unique().tolist()
     df_raked = []

--- a/tests/test_exp_parallel_2D.py
+++ b/tests/test_exp_parallel_2D.py
@@ -55,6 +55,8 @@ def test_parallel(example_2D_draws):
     )
            
     # Use parallelization
+    # The matrix in the objective of the dual has shape (15000, 7000) and full rank.
+    # The solver converges correctly.
     data_builder = DataBuilderParallel(
         dim_specs={"var1": -1, "var2": -1}, dim_parallel=["draws"], value="value", weights="weights"
     )

--- a/tests/test_exp_parallel_2D.py
+++ b/tests/test_exp_parallel_2D.py
@@ -20,8 +20,6 @@ def test_parallel(example_2D_draws):
     df_margins_2.rename(columns={"value_agg_over_var2": "value"}, inplace=True)
     df = pd.concat([df_obs, df_margins_1, df_margins_2])
 
-    df = df.loc[df.draws < 10.5]
-
     # Loop on the draws
     draws = df.draws.unique().tolist()
     df_raked = []

--- a/tests/test_exp_parallel_2D.py
+++ b/tests/test_exp_parallel_2D.py
@@ -1,0 +1,97 @@
+import pytest
+import numpy as np
+import pandas as pd
+from raking.experimental import DataBuilder
+from raking.experimental import DataBuilderParallel
+from raking.experimental import DualSolver
+
+
+def test_parallel(example_2D_draws):
+    df_obs = example_2D_draws.df_obs
+    df_margins_1 = example_2D_draws.df_margins_1
+    df_margins_2 = example_2D_draws.df_margins_2
+    df_obs["weights"] = 1.0
+    df_margins_1["var1"] = -1
+    df_margins_1["weights"] = np.inf
+    df_margins_1.rename(columns={"value_agg_over_var1": "value"}, inplace=True)
+    df_margins_2["var2"] = -1
+    df_margins_2["weights"] = np.inf
+    df_margins_2.rename(columns={"value_agg_over_var2": "value"}, inplace=True)
+    df = pd.concat([df_obs, df_margins_1, df_margins_2])
+
+    # Loop on the draws
+    draws = df.draws.unique().tolist()
+    df_raked = []
+    for draw in draws:
+        df_loc = df.loc[df.draws == draw]
+        data_builder = DataBuilder(
+            dim_specs={"var1": -1, "var2": -1}, value="value", weights="weights"
+        )
+        data = data_builder.build(df_loc)
+        solver = DualSolver(distance="entropic", data=data)
+        soln = solver.solve()
+        soln["draws"] = draw
+        df_raked.append(soln)
+    df_raked = pd.concat(df_raked)
+
+    # Check the results for the loop on the draws
+    sum_over_var1 = (
+        df_raked.groupby(["var2", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_1, on=["var2", "draws"])
+    )
+    assert np.allclose(sum_over_var1["soln"], sum_over_var1["value"]), (
+        "For the loop, the sums over the first variable must match the first margins."
+    )
+    sum_over_var2 = (
+        df_raked.groupby(["var1", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_2, on=["var1", "draws"])
+    )
+    assert np.allclose(sum_over_var2["soln"], sum_over_var2["value"]), (
+        "For the loop, the sums over the second variable must match the second margins."
+    )
+           
+    # Use parallelization
+    data_builder = DataBuilderParallel(
+        dim_specs={"var1": -1, "var2": -1}, dim_parallel=["draws"], value="value", weights="weights"
+    )
+    data = data_builder.build(df)
+    solver = DualSolver(distance="entropic", data=data)
+    df_raked_parallel = solver.solve()
+
+    # Check the results for the parallelization
+    sum_over_var1 = (
+        df_raked_parallel.groupby(["var2", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_1, on=["var2", "draws"])
+    )
+    assert np.allclose(sum_over_var1["soln"], sum_over_var1["value"], 1.0e-4), (
+        "For the parallelization, the sums over the first variable must match the first margins."
+    )
+    sum_over_var2 = (
+        df_raked_parallel.groupby(["var1", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_2, on=["var1", "draws"])
+    )
+    assert np.allclose(sum_over_var2["soln"], sum_over_var2["value"], 1.0e-4), (
+        "For the parallelization, the sums over the second variable must match the second margins."
+    )
+
+    # Compare results
+    df_both = pd.merge(
+        df_raked,
+        df_raked_parallel,
+        on=["var1", "var2", "draws"],
+        how="inner",
+    )
+    assert np.allclose(
+        df_both["soln_x"],
+        df_both["soln_y"],
+        1.0e-4
+    ), "The two rakings must give the same results."
+

--- a/tests/test_exp_parallel_2D.py
+++ b/tests/test_exp_parallel_2D.py
@@ -4,6 +4,7 @@ import pandas as pd
 from raking.experimental import DataBuilder
 from raking.experimental import DataBuilderParallel
 from raking.experimental import DualSolver
+from raking.experimental import DualSolverParallel
 
 
 def test_parallel(example_2D_draws):
@@ -18,6 +19,8 @@ def test_parallel(example_2D_draws):
     df_margins_2["weights"] = np.inf
     df_margins_2.rename(columns={"value_agg_over_var2": "value"}, inplace=True)
     df = pd.concat([df_obs, df_margins_1, df_margins_2])
+
+    df = df.loc[df.draws < 10.5]
 
     # Loop on the draws
     draws = df.draws.unique().tolist()
@@ -53,15 +56,18 @@ def test_parallel(example_2D_draws):
     assert np.allclose(sum_over_var2["soln"], sum_over_var2["value"]), (
         "For the loop, the sums over the second variable must match the second margins."
     )
-           
+
     # Use parallelization
     # The matrix in the objective of the dual has shape (15000, 7000) and full rank.
     # The solver converges correctly.
     data_builder = DataBuilderParallel(
-        dim_specs={"var1": -1, "var2": -1}, dim_parallel=["draws"], value="value", weights="weights"
+        dim_specs={"var1": -1, "var2": -1},
+        dim_parallel=["draws"],
+        value="value",
+        weights="weights",
     )
     data = data_builder.build(df)
-    solver = DualSolver(distance="entropic", data=data)
+    solver = DualSolverParallel(distance="entropic", data=data)
     df_raked_parallel = solver.solve()
 
     # Check the results for the parallelization
@@ -91,9 +97,6 @@ def test_parallel(example_2D_draws):
         on=["var1", "var2", "draws"],
         how="inner",
     )
-    assert np.allclose(
-        df_both["soln_x"],
-        df_both["soln_y"],
-        1.0e-4
-    ), "The two rakings must give the same results."
-
+    assert np.allclose(df_both["soln_x"], df_both["soln_y"], 1.0e-4), (
+        "The two rakings must give the same results."
+    )

--- a/tests/test_exp_parallel_3D.py
+++ b/tests/test_exp_parallel_3D.py
@@ -24,8 +24,6 @@ def test_parallel(example_3D_draws):
     df_margins_3.rename(columns={"value_agg_over_var3": "value"}, inplace=True)
     df = pd.concat([df_obs, df_margins_1, df_margins_2, df_margins_3])
 
-    df = df.loc[df.draws < 10.5]
-
     # Loop on the draws
     draws = df.draws.unique().tolist()
     df_raked = []

--- a/tests/test_exp_parallel_3D.py
+++ b/tests/test_exp_parallel_3D.py
@@ -1,0 +1,124 @@
+import pytest
+import numpy as np
+import pandas as pd
+from raking.experimental import DataBuilder
+from raking.experimental import DataBuilderParallel
+from raking.experimental import DualSolver
+
+
+def test_parallel(example_3D_draws):
+    df_obs = example_3D_draws.df_obs
+    df_margins_1 = example_3D_draws.df_margins_1
+    df_margins_2 = example_3D_draws.df_margins_2
+    df_margins_3 = example_3D_draws.df_margins_3
+    df_obs["weights"] = 1.0
+    df_margins_1["var1"] = -1
+    df_margins_1["weights"] = np.inf
+    df_margins_1.rename(columns={"value_agg_over_var1": "value"}, inplace=True)
+    df_margins_2["var2"] = -1
+    df_margins_2["weights"] = np.inf
+    df_margins_2.rename(columns={"value_agg_over_var2": "value"}, inplace=True)
+    df_margins_3["var3"] = -1
+    df_margins_3["weights"] = np.inf
+    df_margins_3.rename(columns={"value_agg_over_var3": "value"}, inplace=True)
+    df = pd.concat([df_obs, df_margins_1, df_margins_2, df_margins_3])
+
+    # Loop on the draws
+    draws = df.draws.unique().tolist()
+    df_raked = []
+    for draw in draws:
+        df_loc = df.loc[df.draws == draw]
+        data_builder = DataBuilder(
+            dim_specs={"var1": -1, "var2": -1, "var3": -1},
+            value="value",
+            weights="weights",
+        )
+        data = data_builder.build(df_loc)
+        solver = DualSolver(distance="entropic", data=data)
+        soln = solver.solve()
+        soln["draws"] = draw
+        df_raked.append(soln)
+    df_raked = pd.concat(df_raked)
+
+    # Check the results for the loop on the draws
+    sum_over_var1 = (
+        df_raked.groupby(["var2", "var3", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_1, on=["var2", "var3", "draws"])
+    )
+    assert np.allclose(sum_over_var1["soln"], sum_over_var1["value"], 1.0e-4), (
+        "For the loop, the sums over the first variable must match the first margins."
+    )
+    sum_over_var2 = (
+        df_raked.groupby(["var1", "var3", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_2, on=["var1", "var3", "draws"])
+    )
+    assert np.allclose(sum_over_var2["soln"], sum_over_var2["value"], 1.0e-4), (
+        "For the loop, the sums over the second variable must match the second margins."
+    )
+    sum_over_var3 = (
+        df_raked.groupby(["var1", "var2", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_3, on=["var1", "var2", "draws"])
+    )
+    assert np.allclose(sum_over_var3["soln"], sum_over_var3["value"], 1.0e-4), (
+        "For the loop, the sums over the third variable must match the third margins."
+    )
+           
+    # Use parallelization
+    data_builder = DataBuilderParallel(
+        dim_specs={"var1": -1, "var2": -1, "var3": -1},
+        dim_parallel=["draws"],
+        value="value",
+        weights="weights",
+    )
+    data = data_builder.build(df)
+    solver = DualSolver(distance="entropic", data=data)
+    df_raked_parallel = solver.solve()
+
+    # Check the results for the parallelization
+    sum_over_var1 = (
+        df_raked_parallel.groupby(["var2", "var3", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_1, on=["var2", "var3", "draws"])
+    )
+    assert np.allclose(sum_over_var1["soln"], sum_over_var1["value"], 1.0e-3), (
+        "For the parallelization, the sums over the first variable must match the first margins."
+    )
+    sum_over_var2 = (
+        df_raked_parallel.groupby(["var1", "var3", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_2, on=["var1", "var3", "draws"])
+    )
+    assert np.allclose(sum_over_var2["soln"], sum_over_var2["value"], 1.0e-3), (
+        "For the parallelization, the sums over the second variable must match the second margins."
+    )
+    sum_over_var3 = (
+        df_raked_parallel.groupby(["var1", "var2", "draws"])
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margins_3, on=["var1", "var2", "draws"])
+    )
+    assert np.allclose(sum_over_var3["soln"], sum_over_var3["value"], 1.0e-3), (
+        "For the parallelization, the sums over the third variable must match the third margins."
+    )
+
+    # Compare results
+    df_both = pd.merge(
+        df_raked,
+        df_raked_parallel,
+        on=["var1", "var2", "var3", "draws"],
+        how="inner",
+    )
+    assert np.allclose(
+        df_both["soln_x"],
+        df_both["soln_y"],
+        1.0e-3
+    ), "The two rakings must give the same results."
+

--- a/tests/test_exp_parallel_3D.py
+++ b/tests/test_exp_parallel_3D.py
@@ -4,6 +4,7 @@ import pandas as pd
 from raking.experimental import DataBuilder
 from raking.experimental import DataBuilderParallel
 from raking.experimental import DualSolver
+from raking.experimental import DualSolverParallel
 
 
 def test_parallel(example_3D_draws):
@@ -22,6 +23,8 @@ def test_parallel(example_3D_draws):
     df_margins_3["weights"] = np.inf
     df_margins_3.rename(columns={"value_agg_over_var3": "value"}, inplace=True)
     df = pd.concat([df_obs, df_margins_1, df_margins_2, df_margins_3])
+
+    df = df.loc[df.draws < 10.5]
 
     # Loop on the draws
     draws = df.draws.unique().tolist()
@@ -68,7 +71,7 @@ def test_parallel(example_3D_draws):
     assert np.allclose(sum_over_var3["soln"], sum_over_var3["value"], 1.0e-4), (
         "For the loop, the sums over the third variable must match the third margins."
     )
-           
+
     # Use parallelization
     # The matrix in the objective of the dual has shape (60000, 36000) and full rank.
     # The solver converges correctly.
@@ -79,7 +82,7 @@ def test_parallel(example_3D_draws):
         weights="weights",
     )
     data = data_builder.build(df)
-    solver = DualSolver(distance="entropic", data=data)
+    solver = DualSolverParallel(distance="entropic", data=data)
     df_raked_parallel = solver.solve()
 
     # Check the results for the parallelization
@@ -118,9 +121,6 @@ def test_parallel(example_3D_draws):
         on=["var1", "var2", "var3", "draws"],
         how="inner",
     )
-    assert np.allclose(
-        df_both["soln_x"],
-        df_both["soln_y"],
-        1.0e-3
-    ), "The two rakings must give the same results."
-
+    assert np.allclose(df_both["soln_x"], df_both["soln_y"], 1.0e-3), (
+        "The two rakings must give the same results."
+    )

--- a/tests/test_exp_parallel_3D.py
+++ b/tests/test_exp_parallel_3D.py
@@ -70,6 +70,8 @@ def test_parallel(example_3D_draws):
     )
            
     # Use parallelization
+    # The matrix in the objective of the dual has shape (60000, 36000) and full rank.
+    # The solver converges correctly.
     data_builder = DataBuilderParallel(
         dim_specs={"var1": -1, "var2": -1, "var3": -1},
         dim_parallel=["draws"],

--- a/tests/test_exp_parallel_USHD.py
+++ b/tests/test_exp_parallel_USHD.py
@@ -52,7 +52,7 @@ def test_parallel(example_USHD_draws):
     assert np.allclose(
         sum_over_race_county["soln"],
         sum_over_race_county["value"],
-        atol=1.0e-4,
+        atol=1.0e-3,
     ), "For the loop, the sums over race and county must match the GBD values."
            
     # Use parallelization

--- a/tests/test_exp_parallel_USHD.py
+++ b/tests/test_exp_parallel_USHD.py
@@ -4,6 +4,7 @@ import pandas as pd
 from raking.experimental import DataBuilder
 from raking.experimental import DataBuilderParallel
 from raking.experimental import DualSolver
+from raking.experimental import DualSolverParallel
 
 
 def test_parallel(example_USHD_draws):
@@ -24,6 +25,8 @@ def test_parallel(example_USHD_draws):
     )
     df = pd.concat([df_obs, df_margin])
     df = df.astype({"cause": "int64"})
+
+    df = df.loc[df.draws < 10.5]
 
     # Loop on the draws
     draws = df.draws.unique().tolist()
@@ -54,7 +57,7 @@ def test_parallel(example_USHD_draws):
         sum_over_race_county["value"],
         atol=1.0e-3,
     ), "For the loop, the sums over race and county must match the GBD values."
-           
+
     # Use parallelization
     data_builder = DataBuilderParallel(
         dim_specs={"cause": -1, "race": -1, "county": -1},
@@ -63,7 +66,7 @@ def test_parallel(example_USHD_draws):
         weights="weights",
     )
     data = data_builder.build(df)
-    solver = DualSolver(distance="entropic", data=data)
+    solver = DualSolverParallel(distance="entropic", data=data)
     df_raked_parallel = solver.solve()
 
     # Check the results for the parallelization
@@ -76,8 +79,10 @@ def test_parallel(example_USHD_draws):
     assert np.allclose(
         sum_over_race_county["soln"],
         sum_over_race_county["value"],
-        atol=1.0e-5,
-    ), "For the parallelization, the sums over race and county must match the GBD values."
+        atol=1.0e-3,
+    ), (
+        "For the parallelization, the sums over race and county must match the GBD values."
+    )
 
     # Compare results
     df_both = pd.merge(
@@ -86,9 +91,6 @@ def test_parallel(example_USHD_draws):
         on=["cause", "race", "county", "draws"],
         how="inner",
     )
-    assert np.allclose(
-        df_both["soln_x"],
-        df_both["soln_y"],
-        1.0e-3
-    ), "The two rakings must give the same results."
-
+    assert np.allclose(df_both["soln_x"], df_both["soln_y"], 1.0e-2), (
+        "The two rakings must give the same results."
+    )

--- a/tests/test_exp_parallel_USHD.py
+++ b/tests/test_exp_parallel_USHD.py
@@ -1,0 +1,94 @@
+import pytest
+import numpy as np
+import pandas as pd
+from raking.experimental import DataBuilder
+from raking.experimental import DataBuilderParallel
+from raking.experimental import DualSolver
+
+
+def test_parallel(example_USHD_draws):
+    df_obs = example_USHD_draws.df_obs
+    df_margin = example_USHD_draws.df_margins
+    df_obs["weights"] = 1.0
+    df_obs.replace({"cause": "_all", "race": 1}, -1, inplace=True)
+    df_obs.drop(columns=["upper"], inplace=True)
+    df_obs.replace({"cause": {"_comm": 1, "_inj": 2, "_ncd": 3}}, inplace=True)
+    df_margin["race"] = -1
+    df_margin["county"] = -1
+    df_margin["weights"] = np.inf
+    df_margin.rename(
+        columns={"value_agg_over_race_county": "value"}, inplace=True
+    )
+    df_margin.replace(
+        {"cause": {"_all": -1, "_comm": 1, "_inj": 2, "_ncd": 3}}, inplace=True
+    )
+    df = pd.concat([df_obs, df_margin])
+    df = df.astype({"cause": "int64"})
+
+    # Loop on the draws
+    draws = df.draws.unique().tolist()
+    df_raked = []
+    for draw in draws:
+        df_loc = df.loc[df.draws == draw]
+        data_builder = DataBuilder(
+            dim_specs={"cause": -1, "race": -1, "county": -1},
+            value="value",
+            weights="weights",
+        )
+        data = data_builder.build(df_loc)
+        solver = DualSolver(distance="entropic", data=data)
+        soln = solver.solve()
+        soln["draws"] = draw
+        df_raked.append(soln)
+    df_raked = pd.concat(df_raked)
+
+    # Check the results for the loop on the draws
+    sum_over_race_county = (
+        df_raked.groupby(["cause", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin, on=["cause", "draws"])
+    )
+    assert np.allclose(
+        sum_over_race_county["soln"],
+        sum_over_race_county["value"],
+        atol=1.0e-4,
+    ), "For the loop, the sums over race and county must match the GBD values."
+           
+    # Use parallelization
+    data_builder = DataBuilderParallel(
+        dim_specs={"cause": -1, "race": -1, "county": -1},
+        dim_parallel=["draws"],
+        value="value",
+        weights="weights",
+    )
+    data = data_builder.build(df)
+    solver = DualSolver(distance="entropic", data=data)
+    df_raked_parallel = solver.solve()
+
+    # Check the results for the parallelization
+    sum_over_race_county = (
+        df_raked_parallel.groupby(["cause", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin, on=["cause", "draws"])
+    )
+    assert np.allclose(
+        sum_over_race_county["soln"],
+        sum_over_race_county["value"],
+        atol=1.0e-5,
+    ), "For the parallelization, the sums over race and county must match the GBD values."
+
+    # Compare results
+    df_both = pd.merge(
+        df_raked,
+        df_raked_parallel,
+        on=["cause", "race", "county", "draws"],
+        how="inner",
+    )
+    assert np.allclose(
+        df_both["soln_x"],
+        df_both["soln_y"],
+        1.0e-3
+    ), "The two rakings must give the same results."
+

--- a/tests/test_exp_parallel_USHD.py
+++ b/tests/test_exp_parallel_USHD.py
@@ -26,8 +26,6 @@ def test_parallel(example_USHD_draws):
     df = pd.concat([df_obs, df_margin])
     df = df.astype({"cause": "int64"})
 
-    df = df.loc[df.draws < 10.5]
-
     # Loop on the draws
     draws = df.draws.unique().tolist()
     df_raked = []
@@ -55,7 +53,7 @@ def test_parallel(example_USHD_draws):
     assert np.allclose(
         sum_over_race_county["soln"],
         sum_over_race_county["value"],
-        atol=1.0e-3,
+        atol=1.0e-4,
     ), "For the loop, the sums over race and county must match the GBD values."
 
     # Use parallelization
@@ -78,8 +76,7 @@ def test_parallel(example_USHD_draws):
     )
     assert np.allclose(
         sum_over_race_county["soln"],
-        sum_over_race_county["value"],
-        atol=1.0e-3,
+        sum_over_race_county["value"]
     ), (
         "For the parallelization, the sums over race and county must match the GBD values."
     )

--- a/tests/test_exp_parallel_USHD_lower.py
+++ b/tests/test_exp_parallel_USHD_lower.py
@@ -1,0 +1,143 @@
+import pytest
+import numpy as np
+import pandas as pd
+from raking.experimental import DataBuilder
+from raking.experimental import DataBuilderParallel
+from raking.experimental import DualSolver
+
+
+def test_parallel(example_USHD_lower_draws):
+    df_obs = example_USHD_lower_draws.df_obs
+    df_margin_cause = example_USHD_lower_draws.df_margins_cause
+    df_margin_county = example_USHD_lower_draws.df_margins_county
+    df_margin_all_causes = example_USHD_lower_draws.df_margins_all_causes
+    df_obs["weights"] = 1.0
+    df_obs.replace({"race": 1}, -1, inplace=True)
+    df_obs.drop(columns=["upper"], inplace=True)
+    df_obs.replace({"cause": {"_intent": 1, "_unintent": 2, "inj_trans": 3}}, inplace=True)
+    df_margin_cause["race"] = -1
+    df_margin_cause["county"] = -1
+    df_margin_cause["weights"] = np.inf
+    df_margin_cause.rename(columns={"value_agg_over_race_county": "value"}, inplace=True)
+    df_margin_cause.replace({"cause": {"_intent": 1, "_unintent": 2, "inj_trans": 3}}, inplace=True)
+    df_margin_county["cause"] = -1
+    df_margin_county["race"] = -1
+    df_margin_county["weights"] = np.inf
+    df_margin_county.rename(columns={"value_agg_over_cause_race": "value"}, inplace=True)
+    df_margin_all_causes["cause"] = -1
+    df_margin_all_causes["weights"] = np.inf
+    df_margin_all_causes.rename(columns={"value_agg_over_cause": "value"}, inplace=True)
+    df = pd.concat([df_obs, df_margin_cause, df_margin_county, df_margin_all_causes])
+    df = df.astype({"cause": "int64"})
+
+    # Loop on the draws
+    draws = df.draws.unique().tolist()
+    df_raked = []
+    for draw in draws:
+        df_loc = df.loc[df.draws == draw]
+        data_builder = DataBuilder(
+            dim_specs={"cause": -1, "race": -1, "county": -1},
+            value="value",
+            weights="weights",
+        )
+        data = data_builder.build(df_loc)
+        solver = DualSolver(distance="entropic", data=data)
+        soln = solver.solve()
+        soln["draws"] = draw
+        df_raked.append(soln)
+    df_raked = pd.concat(df_raked)
+
+    # Check the results for the loop on the draws
+    sum_over_cause = (
+        df_raked.groupby(["race", "county", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin_all_causes, on=["race", "county", "draws"])
+    )
+    sum_over_cause_race = (
+        df_raked.groupby(["county", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin_county, on=["county", "draws"])
+    )
+    sum_over_race_county = (
+        df_raked.groupby(["cause", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin_cause, on=["cause", "draws"])
+    )
+    assert np.allclose(
+        sum_over_cause["soln"],
+        sum_over_cause["value"],
+        atol=1.0e-5,
+    ), "For the loop, the sums over cause must match the margins."
+    assert np.allclose(
+        sum_over_cause_race["soln"],
+        sum_over_cause_race["value"],
+        atol=1.0e-4,
+    ), "For the loop, the sums over cause and race must match the margins."
+    assert np.allclose(
+        sum_over_race_county["soln"],
+        sum_over_race_county["value"],
+        atol=1.0e-5,
+    ), "For the loop, the sums over race and county must match the GBD values."
+           
+    # Use parallelization
+    data_builder = DataBuilderParallel(
+        dim_specs={"cause": -1, "race": -1, "county": -1},
+        dim_parallel=["draws"],
+        value="value",
+        weights="weights",
+    )
+    data = data_builder.build(df)
+    solver = DualSolver(distance="entropic", data=data)
+    df_raked_parallel = solver.solve()
+
+    # Check the results for the parallelization
+    sum_over_cause = (
+        df_raked_parallel.groupby(["race", "county", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin_all_causes, on=["race", "county", "draws"])
+    )
+    sum_over_cause_race = (
+        df_raked_parallel.groupby(["county", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin_county, on=["county", "draws"])
+    )
+    sum_over_race_county = (
+        df_raked_parallel.groupby(["cause", "draws"], observed=True)
+        .agg({"soln": "sum"})
+        .reset_index()
+        .merge(df_margin_cause, on=["cause", "draws"])
+    )
+    assert np.allclose(
+        sum_over_cause["soln"],
+        sum_over_cause["value"],
+        atol=1.0e-5,
+    ), "For the parallelization, the sums over cause must match the margins."
+    assert np.allclose(
+        sum_over_cause_race["soln"],
+        sum_over_cause_race["value"],
+        atol=1.0e-4,
+    ), "For the parallelization, the sums over cause and race must match the margins."
+    assert np.allclose(
+        sum_over_race_county["soln"],
+        sum_over_race_county["value"],
+        atol=1.0e-5,
+    ), "For the parallelization, the sums over race and county must match the GBD values."
+
+    # Compare results
+    df_both = pd.merge(
+        df_raked,
+        df_raked_parallel,
+        on=["cause", "race", "county", "draws"],
+        how="inner",
+    )
+    assert np.allclose(
+        df_both["soln_x"],
+        df_both["soln_y"],
+        1.0e-3
+    ), "The two rakings must give the same results."
+

--- a/tests/test_exp_parallel_USHD_lower.py
+++ b/tests/test_exp_parallel_USHD_lower.py
@@ -43,8 +43,6 @@ def test_parallel(example_USHD_lower_draws):
     )
     df = df.astype({"cause": "int64"})
 
-    df = df.loc[df.draws < 10.5]
-
     df = df.loc[(df["cause"] != -1) | (df["race"] != 2) | (df["county"] != 301)]
 
     # Loop on the draws
@@ -136,15 +134,13 @@ def test_parallel(example_USHD_lower_draws):
     ), "For the parallelization, the sums over cause must match the margins."
     assert np.allclose(
         sum_over_cause_race["soln"],
-        sum_over_cause_race["value"],
-        atol=1.0e-5,
+        sum_over_cause_race["value"]
     ), (
         "For the parallelization, the sums over cause and race must match the margins."
     )
     assert np.allclose(
         sum_over_race_county["soln"],
         sum_over_race_county["value"],
-        atol=1.0e-5,
     ), (
         "For the parallelization, the sums over race and county must match the GBD values."
     )
@@ -156,6 +152,6 @@ def test_parallel(example_USHD_lower_draws):
         on=["cause", "race", "county", "draws"],
         how="inner",
     )
-    assert np.allclose(df_both["soln_x"], df_both["soln_y"], 2.0e-2), (
+    assert np.allclose(df_both["soln_x"], df_both["soln_y"], 1.0e-2), (
         "The two rakings must give the same results."
     )

--- a/tests/test_exp_parallel_USHD_lower.py
+++ b/tests/test_exp_parallel_USHD_lower.py
@@ -4,6 +4,7 @@ import pandas as pd
 from raking.experimental import DataBuilder
 from raking.experimental import DataBuilderParallel
 from raking.experimental import DualSolver
+from raking.experimental import DualSolverParallel
 
 
 def test_parallel(example_USHD_lower_draws):
@@ -14,21 +15,37 @@ def test_parallel(example_USHD_lower_draws):
     df_obs["weights"] = 1.0
     df_obs.replace({"race": 1}, -1, inplace=True)
     df_obs.drop(columns=["upper"], inplace=True)
-    df_obs.replace({"cause": {"_intent": 1, "_unintent": 2, "inj_trans": 3}}, inplace=True)
+    df_obs.replace(
+        {"cause": {"_intent": 1, "_unintent": 2, "inj_trans": 3}}, inplace=True
+    )
     df_margin_cause["race"] = -1
     df_margin_cause["county"] = -1
     df_margin_cause["weights"] = np.inf
-    df_margin_cause.rename(columns={"value_agg_over_race_county": "value"}, inplace=True)
-    df_margin_cause.replace({"cause": {"_intent": 1, "_unintent": 2, "inj_trans": 3}}, inplace=True)
+    df_margin_cause.rename(
+        columns={"value_agg_over_race_county": "value"}, inplace=True
+    )
+    df_margin_cause.replace(
+        {"cause": {"_intent": 1, "_unintent": 2, "inj_trans": 3}}, inplace=True
+    )
     df_margin_county["cause"] = -1
     df_margin_county["race"] = -1
     df_margin_county["weights"] = np.inf
-    df_margin_county.rename(columns={"value_agg_over_cause_race": "value"}, inplace=True)
+    df_margin_county.rename(
+        columns={"value_agg_over_cause_race": "value"}, inplace=True
+    )
     df_margin_all_causes["cause"] = -1
     df_margin_all_causes["weights"] = np.inf
-    df_margin_all_causes.rename(columns={"value_agg_over_cause": "value"}, inplace=True)
-    df = pd.concat([df_obs, df_margin_cause, df_margin_county, df_margin_all_causes])
+    df_margin_all_causes.rename(
+        columns={"value_agg_over_cause": "value"}, inplace=True
+    )
+    df = pd.concat(
+        [df_obs, df_margin_cause, df_margin_county, df_margin_all_causes]
+    )
     df = df.astype({"cause": "int64"})
+
+    df = df.loc[df.draws < 10.5]
+
+    df = df.loc[(df["cause"] != -1) | (df["race"] != 2) | (df["county"] != 301)]
 
     # Loop on the draws
     draws = df.draws.unique().tolist()
@@ -74,14 +91,14 @@ def test_parallel(example_USHD_lower_draws):
     assert np.allclose(
         sum_over_cause_race["soln"],
         sum_over_cause_race["value"],
-        atol=1.0e-4,
+        atol=1.0e-5,
     ), "For the loop, the sums over cause and race must match the margins."
     assert np.allclose(
         sum_over_race_county["soln"],
         sum_over_race_county["value"],
         atol=1.0e-5,
     ), "For the loop, the sums over race and county must match the GBD values."
-           
+
     # Use parallelization
     data_builder = DataBuilderParallel(
         dim_specs={"cause": -1, "race": -1, "county": -1},
@@ -90,7 +107,7 @@ def test_parallel(example_USHD_lower_draws):
         weights="weights",
     )
     data = data_builder.build(df)
-    solver = DualSolver(distance="entropic", data=data)
+    solver = DualSolverParallel(distance="entropic", data=data)
     df_raked_parallel = solver.solve()
 
     # Check the results for the parallelization
@@ -120,13 +137,17 @@ def test_parallel(example_USHD_lower_draws):
     assert np.allclose(
         sum_over_cause_race["soln"],
         sum_over_cause_race["value"],
-        atol=1.0e-4,
-    ), "For the parallelization, the sums over cause and race must match the margins."
+        atol=1.0e-5,
+    ), (
+        "For the parallelization, the sums over cause and race must match the margins."
+    )
     assert np.allclose(
         sum_over_race_county["soln"],
         sum_over_race_county["value"],
         atol=1.0e-5,
-    ), "For the parallelization, the sums over race and county must match the GBD values."
+    ), (
+        "For the parallelization, the sums over race and county must match the GBD values."
+    )
 
     # Compare results
     df_both = pd.merge(
@@ -135,9 +156,6 @@ def test_parallel(example_USHD_lower_draws):
         on=["cause", "race", "county", "draws"],
         how="inner",
     )
-    assert np.allclose(
-        df_both["soln_x"],
-        df_both["soln_y"],
-        1.0e-3
-    ), "The two rakings must give the same results."
-
+    assert np.allclose(df_both["soln_x"], df_both["soln_y"], 2.0e-2), (
+        "The two rakings must give the same results."
+    )

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -6,6 +6,11 @@ from raking.experimental import DualSolver
 
 
 def test_exp_raking_1D(example_1D):
+    """
+    Test 1D example.
+    The matrix in the objective of the dual has shape (3, 1) and full rank.
+    The solver converges correctly.
+    """
     df_obs = example_1D.df_obs
     df_margin = example_1D.df_margin
     df_obs["weights"] = 1.0
@@ -25,6 +30,11 @@ def test_exp_raking_1D(example_1D):
 
 
 def test_exp_raking_2D(example_2D):
+    """
+    Test 2D example.
+    The matrix in the objective of the dual has shape (15, 7) and full rank.
+    The solver converges correctly.
+    """
     df_obs = example_2D.df_obs
     df_margins_1 = example_2D.df_margins_1
     df_margins_2 = example_2D.df_margins_2
@@ -63,6 +73,11 @@ def test_exp_raking_2D(example_2D):
 
 
 def test_exp_raking_3D(example_3D):
+    """
+    Test 3D example.
+    The matrix in the objective of the dual has shape (60, 36) and full rank.
+    The solver converges correctly.
+    """
     df_obs = example_3D.df_obs
     df_margins_1 = example_3D.df_margins_1
     df_margins_2 = example_3D.df_margins_2
@@ -116,6 +131,11 @@ def test_exp_raking_3D(example_3D):
 
 
 def test_exp_raking_USHD(example_USHD):
+    """
+    Test USHD example.
+    The matrix in the objective of the dual has shape (72, 30) and full rank.
+    The solver converges correctly.
+    """
     df_obs = example_USHD.df_obs
     df_margin = example_USHD.df_margins
     df_obs["weights"] = 1.0
@@ -155,6 +175,12 @@ def test_exp_raking_USHD(example_USHD):
 
 
 def test_exp_raking_USHD_lower(example_USHD_lower):
+    """
+    Test USHD_lower example.
+    The matrix in the objective of the dual has shape (54, 27) and rank 26
+    when it should have shape (54, 26) and full rank.
+    That does not prevent the solver from converging correctly.
+    """
     df_obs = example_USHD_lower.df_obs
     df_margin_cause = example_USHD_lower.df_margins_cause
     df_margin_county = example_USHD_lower.df_margins_county

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -480,7 +480,7 @@ def test_exp_raking_USHD_weights(example_USHD_draws):
     assert np.allclose(
         sum_over_race_county["soln"],
         sum_over_race_county["value"],
-        atol=1.0e-5,
+        atol=1.0e-4,
     ), "The sums over race and county must match the GBD values."
 
 

--- a/tests/test_raking_parallel.py
+++ b/tests/test_raking_parallel.py
@@ -1,7 +1,10 @@
 import pytest
 import numpy as np
 import pandas as pd
-from raking.compute_constraints import constraints_USHD_lower, constraints_USHD_lower_parallel
+from raking.compute_constraints import (
+    constraints_USHD_lower,
+    constraints_USHD_lower_parallel,
+)
 from raking.raking_methods import raking_entropic, raking_entropic_parallel
 from raking.run_raking import run_raking
 
@@ -16,10 +19,16 @@ def test_USHD_lower(example_USHD_lower_draws):
     draws = df_obs.draws.unique().tolist()
     df_raked = []
     for draw in draws:
-        df_obs_loc = df_obs.loc[df_obs.draws==draw]
-        df_margins_cause_loc = df_margins_cause.loc[df_margins_cause.draws==draw]
-        df_margins_county_loc = df_margins_county.loc[df_margins_county.draws==draw]
-        df_margins_all_causes_loc = df_margins_all_causes.loc[df_margins_all_causes.draws==draw]
+        df_obs_loc = df_obs.loc[df_obs.draws == draw]
+        df_margins_cause_loc = df_margins_cause.loc[
+            df_margins_cause.draws == draw
+        ]
+        df_margins_county_loc = df_margins_county.loc[
+            df_margins_county.draws == draw
+        ]
+        df_margins_all_causes_loc = df_margins_all_causes.loc[
+            df_margins_all_causes.draws == draw
+        ]
         (df_obs_loc, Dphi_y, Dphi_s, sigma) = run_raking(
             dim="USHD_lower",
             df_obs=df_obs_loc,
@@ -31,7 +40,7 @@ def test_USHD_lower(example_USHD_lower_draws):
             var_names=None,
             margin_names=["_inj", 1, 0],
             cov_mat=False,
-            method="entropic"
+            method="entropic",
         )
         df_raked.append(df_obs_loc)
     df_raked = pd.concat(df_raked)
@@ -51,11 +60,11 @@ def test_USHD_lower(example_USHD_lower_draws):
     ), "The sums over the cause must match the all causes deaths."
     sum_over_cause_race = (
         df_raked.loc[df_raked.race == 1]
-             .groupby(["county", "draws"], observed=True)
-             .agg({"raked_value": "sum"})
-             .reset_index()
-             .merge(df_margins_county, on=["county", "draws"])
-        )
+        .groupby(["county", "draws"], observed=True)
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(df_margins_county, on=["county", "draws"])
+    )
     assert np.allclose(
         sum_over_cause_race["raked_value"],
         sum_over_cause_race["value_agg_over_cause_race"],
@@ -65,10 +74,12 @@ def test_USHD_lower(example_USHD_lower_draws):
     )
     sum_over_race = (
         df_raked.loc[df_raked.race != 1]
-             .groupby(["cause", "county", "draws"], observed=True)
-             .agg({"raked_value": "sum"})
-             .reset_index()
-             .merge(df_raked.loc[df_raked.race == 1], on=["cause", "county", "draws"])
+        .groupby(["cause", "county", "draws"], observed=True)
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(
+            df_raked.loc[df_raked.race == 1], on=["cause", "county", "draws"]
+        )
     )
     assert np.allclose(
         sum_over_race["raked_value_x"],
@@ -77,11 +88,11 @@ def test_USHD_lower(example_USHD_lower_draws):
     ), "The sums over the race must match the all races deaths."
     sum_over_race_county = (
         df_raked.loc[df_raked.race != 1]
-             .groupby(["cause", "draws"], observed=True)
-             .agg({"raked_value": "sum"})
-             .reset_index()
-             .merge(df_margins_cause, on=["cause", "draws"])
-        )
+        .groupby(["cause", "draws"], observed=True)
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(df_margins_cause, on=["cause", "draws"])
+    )
     assert np.allclose(
         sum_over_race_county["raked_value"],
         sum_over_race_county["value_agg_over_race_county"],
@@ -90,18 +101,21 @@ def test_USHD_lower(example_USHD_lower_draws):
 
     # Use parallelization
     df_raked_parallel = df_obs.copy(deep=True)
-    df_raked_parallel = df_raked_parallel. \
-        drop(columns=["upper"]). \
-        sort_values(by=["draws", "county", "race", "cause"])
+    df_raked_parallel = df_raked_parallel.drop(columns=["upper"]).sort_values(
+        by=["draws", "county", "race", "cause"]
+    )
     df_margins_cause_parallel = df_margins_cause.copy(deep=True)
-    df_margins_cause_parallel = df_margins_cause_parallel. \
-        sort_values(by=["draws", "cause"])
+    df_margins_cause_parallel = df_margins_cause_parallel.sort_values(
+        by=["draws", "cause"]
+    )
     df_margins_county_parallel = df_margins_county.copy(deep=True)
-    df_margins_county_parallel = df_margins_county_parallel. \
-        sort_values(by=["draws", "county"])
+    df_margins_county_parallel = df_margins_county_parallel.sort_values(
+        by=["draws", "county"]
+    )
     df_margins_all_causes_parallel = df_margins_all_causes.copy(deep=True)
-    df_margins_all_causes = df_margins_all_causes. \
-        sort_values(by=["draws", "county", "race"])
+    df_margins_all_causes = df_margins_all_causes.sort_values(
+        by=["draws", "county", "race"]
+    )
 
     I = len(df_raked_parallel.cause.unique())
     J = len(df_raked_parallel.race.unique()) - 1
@@ -109,10 +123,17 @@ def test_USHD_lower(example_USHD_lower_draws):
     N = len(df_raked_parallel.draws.unique())
 
     s_cause = df_margins_cause_parallel.value_agg_over_race_county.to_numpy()
-    s_county = np.reshape(df_margins_county_parallel.value_agg_over_cause_race.to_numpy(), \
-        (N, K), 'C')[:, 0:(K - 1)].flatten('C')
-    s_all_causes = df_margins_all_causes_parallel.value_agg_over_cause.to_numpy()
-    (A, s) = constraints_USHD_lower_parallel(s_cause, s_county, s_all_causes, I, J, K, N)
+    s_county = np.reshape(
+        df_margins_county_parallel.value_agg_over_cause_race.to_numpy(),
+        (N, K),
+        "C",
+    )[:, 0 : (K - 1)].flatten("C")
+    s_all_causes = (
+        df_margins_all_causes_parallel.value_agg_over_cause.to_numpy()
+    )
+    (A, s) = constraints_USHD_lower_parallel(
+        s_cause, s_county, s_all_causes, I, J, K, N
+    )
     y = df_raked_parallel["value"].to_numpy()
     q = np.ones(len(y))
     (beta, lambda_k, iter_eps) = raking_entropic_parallel(y, A, s, q)
@@ -133,11 +154,11 @@ def test_USHD_lower(example_USHD_lower_draws):
     ), "The sums over the cause must match the all causes deaths."
     sum_over_cause_race = (
         df_raked_parallel.loc[df_raked_parallel.race == 1]
-             .groupby(["county", "draws"], observed=True)
-             .agg({"raked_value": "sum"})
-             .reset_index()
-             .merge(df_margins_county_parallel, on=["county", "draws"])
-        )
+        .groupby(["county", "draws"], observed=True)
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(df_margins_county_parallel, on=["county", "draws"])
+    )
     assert np.allclose(
         sum_over_cause_race["raked_value"],
         sum_over_cause_race["value_agg_over_cause_race"],
@@ -147,10 +168,13 @@ def test_USHD_lower(example_USHD_lower_draws):
     )
     sum_over_race = (
         df_raked_parallel.loc[df_raked_parallel.race != 1]
-             .groupby(["cause", "county", "draws"], observed=True)
-             .agg({"raked_value": "sum"})
-             .reset_index()
-             .merge(df_raked_parallel.loc[df_raked_parallel.race == 1], on=["cause", "county", "draws"])
+        .groupby(["cause", "county", "draws"], observed=True)
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(
+            df_raked_parallel.loc[df_raked_parallel.race == 1],
+            on=["cause", "county", "draws"],
+        )
     )
     assert np.allclose(
         sum_over_race["raked_value_x"],
@@ -159,11 +183,11 @@ def test_USHD_lower(example_USHD_lower_draws):
     ), "The sums over the race must match the all races deaths."
     sum_over_race_county = (
         df_raked_parallel.loc[df_raked_parallel.race != 1]
-             .groupby(["cause", "draws"], observed=True)
-             .agg({"raked_value": "sum"})
-             .reset_index()
-             .merge(df_margins_cause_parallel, on=["cause", "draws"])
-        )
+        .groupby(["cause", "draws"], observed=True)
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(df_margins_cause_parallel, on=["cause", "draws"])
+    )
     assert np.allclose(
         sum_over_race_county["raked_value"],
         sum_over_race_county["value_agg_over_race_county"],
@@ -171,11 +195,14 @@ def test_USHD_lower(example_USHD_lower_draws):
     ), "The sums over race and county must match the GBD values."
 
     # Compare results
-    df_both = pd.merge(df_raked, df_raked_parallel, \
-        on=["cause", "race", "county", "draws"], how="inner")
+    df_both = pd.merge(
+        df_raked,
+        df_raked_parallel,
+        on=["cause", "race", "county", "draws"],
+        how="inner",
+    )
     assert np.allclose(
         df_both["raked_value_x"],
         df_both["raked_value_y"],
         atol=1.0e-10,
     ), "The two rakings must give the same results."
-    

--- a/tests/test_raking_parallel.py
+++ b/tests/test_raking_parallel.py
@@ -2,11 +2,93 @@ import pytest
 import numpy as np
 import pandas as pd
 from raking.compute_constraints import (
+    constraints_1D,
+    constraints_1D_parallel,
     constraints_USHD_lower,
     constraints_USHD_lower_parallel,
 )
 from raking.raking_methods import raking_entropic, raking_entropic_parallel
 from raking.run_raking import run_raking
+
+
+def test_1D(example_1D_draws):
+    df_obs = example_1D_draws.df_obs
+    df_margins = example_1D_draws.df_margin
+
+    # Loop on the draws
+    draws = df_obs.draws.unique().tolist()
+    df_raked = []
+    for draw in draws:
+        df_obs_loc = df_obs.loc[df_obs.draws == draw]
+        df_margins_loc = df_margins.loc[
+            df_margins.draws == draw
+        ]
+        (df_obs_loc, Dphi_y, Dphi_s, sigma) = run_raking(
+            dim=1,
+            df_obs=df_obs_loc,
+            df_margins=[df_margins_loc],
+            var_names=["var1"],
+            cov_mat=False,
+        )
+        df_raked.append(df_obs_loc)
+    df_raked = pd.concat(df_raked)
+
+    # Check the results for the loop on the draws
+    sum_over_var1 = (
+        df_raked
+        .groupby(["draws"])
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(df_margins, on=["draws"])
+    )
+    assert np.allclose(
+        sum_over_var1["raked_value"],
+        sum_over_var1["value_agg_over_var1"],
+        atol=1.0e-5,
+    ), "The raked values do not sum to the margin."
+
+    # Use parallelization
+    df_raked_parallel = df_obs.copy(deep=True)
+    df_raked_parallel = df_raked_parallel.sort_values(by=["draws", "var1"])
+    df_margins_parallel = df_margins.copy(deep=True)
+    df_margins_parallel = df_margins_parallel.sort_values(by=["draws"])
+
+    I = len(df_raked_parallel.var1.unique())
+    N = len(df_raked_parallel.draws.unique())
+
+    s = df_margins_parallel.value_agg_over_var1.to_numpy()
+    (A, s) = constraints_1D_parallel(s, I, N)
+    y = df_raked_parallel["value"].to_numpy()
+    q = np.ones(len(y))
+    (beta, lambda_k, iter_eps) = raking_entropic_parallel(y, A, s, q)
+    df_raked_parallel["raked_value"] = beta
+
+    # Check the results for the parallelization
+    sum_over_var1 = (
+        df_raked_parallel
+        .groupby(["draws"])
+        .agg({"raked_value": "sum"})
+        .reset_index()
+        .merge(df_margins, on=["draws"])
+    )
+    assert np.allclose(
+        sum_over_var1["raked_value"],
+        sum_over_var1["value_agg_over_var1"],
+        atol=1.0e-5,
+    ), "The raked values do not sum to the margin."
+
+    # Compare results
+    df_both = pd.merge(
+        df_raked,
+        df_raked_parallel,
+        on=["var1", "draws"],
+        how="inner",
+    )
+    assert np.allclose(
+        df_both["raked_value_x"],
+        df_both["raked_value_y"],
+        atol=1.0e-11,
+    ), "The two rakings must give the same results."
 
 
 def test_USHD_lower(example_USHD_lower_draws):


### PR DESCRIPTION
This is a draft of a pull request as the tests to not all pass yet.

In the data builder, modify functions _build_design_mat and _sort_rows to make them faster.

Create a new data builder parallel to be able to rake in parallel over several dimensions (like draws or years). Create corresponding tests to verify that raking in parallel produces the same result as looping on the draws and raking each draw.

The test for the USHD example fails, though I am under the impression that the problem comes from the solver, not the data builder. Maybe we should think about how we initialize the solver.