### PR TITLE
Bugfix/sort rows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "raking"
-version = "0.2.0"
+version = "0.2.1"
 description = "Python package template"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/raking/experimental/data.py
+++ b/src/raking/experimental/data.py
@@ -206,11 +206,11 @@ class DataBuilder(BaseModel):
 
     def _sort_rows(self, df: pd.DataFrame) -> pd.DataFrame:
         """Sort the rows of the data frame by constraint status, margin status and categorical variable."""
-        sort_columns = [f"{dim_name}_ordering" for dim_name in self.space.names]
+        sort_columns = [f"_{dim_name}_order" for dim_name in self.space.names]
         for col, dim in zip(sort_columns, self.space.dimensions):
-            dim_ordering = list(dim.grid) + [dim.null]
+            dim_order = list(dim.grid) + [dim.null]
             df[col] = df[dim.name].astype(
-                CategoricalDtype(categories=dim_ordering, ordered=True)
+                CategoricalDtype(categories=dim_order, ordered=True)
             )
         df = df.sort_values(
             ["is_constr", "level"] + sort_columns, ignore_index=True

--- a/src/raking/experimental/data.py
+++ b/src/raking/experimental/data.py
@@ -206,20 +206,15 @@ class DataBuilder(BaseModel):
 
     def _sort_rows(self, df: pd.DataFrame) -> pd.DataFrame:
         """Sort the rows of the data frame by constraint status, margin status and categorical variable."""
-        columns = [name for name in self.space.names]
-        column_types = []
-        for dim in self.space.dimensions:
-            column_types.append(df[dim.name].dtypes)
-            dim_names = df[dim.name].unique().tolist()
-            if dim.null in dim_names:
-                dim_names.remove(dim.null)
-            dim_ordering = dim_names + [dim.null]
-            df[dim.name] = df[dim.name].astype(
+        sort_columns = [f"{dim_name}_ordering" for dim_name in self.space.names]
+        for col, dim in zip(sort_columns, self.space.dimensions):
+            dim_ordering = list(dim.grid) + [dim.null]
+            df[col] = df[dim.name].astype(
                 CategoricalDtype(categories=dim_ordering, ordered=True)
             )
-        df = df.sort_values(["is_constr", "level"] + columns, ignore_index=True)
-        for dim, column_type in zip(self.space.dimensions, column_types):
-            df[dim.name] = df[dim.name].astype(column_type)
+        df = df.sort_values(
+            ["is_constr", "level"] + sort_columns, ignore_index=True
+        ).drop(columns=sort_columns)
         return df
 
     def _expand_observ(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -586,3 +586,42 @@ def test_exp_raking_USHD_lower_weights(example_USHD_lower_draws):
         sum_over_race_county["value"],
         atol=1.0e-5,
     ), "The sums over race and county must match the GBD values."
+
+
+def test_sort_rows_independent_of_input_order():
+    """The row ordering produced by `_sort_rows` must follow the dimension
+    grid, not the order in which categories happen to appear in the input
+    data frame. Previously the ordering was derived from
+    `df[dim.name].unique()`, so the same data shuffled differently sorted
+    differently. With the fix the ordering is driven by `dim.grid`, which is
+    fixed at build time, so the result is independent of the input order.
+    """
+    df = pd.DataFrame(
+        {
+            "var1": [1, 2, 3],
+            "value": [10.0, 20.0, 30.0],
+            "weights": [1.0, 1.0, 1.0],
+        }
+    )
+    data_builder = DataBuilder(
+        dim_specs={"var1": -1}, value="value", weights="weights"
+    )
+    # Build the space from the ordered frame -> grid == (1, 2, 3).
+    data_builder._build_space(df)
+
+    def prep(frame):
+        return (
+            frame.pipe(data_builder._subset_columns)
+            .pipe(data_builder._assign_level)
+            .pipe(data_builder._assign_indicators)
+        )
+
+    sorted_ordered = data_builder._sort_rows(prep(df.copy()))
+    # Same data, rows reversed: var1 first appears as [3, 2, 1].
+    shuffled = df.iloc[[2, 1, 0]].reset_index(drop=True)
+    sorted_shuffled = data_builder._sort_rows(prep(shuffled))
+
+    pd.testing.assert_frame_equal(sorted_ordered, sorted_shuffled)
+    assert sorted_shuffled["var1"].tolist() == [1, 2, 3], (
+        "Rows must be ordered by the dimension grid, not by input order."
+    )


### PR DESCRIPTION
## Summary

`DataBuilder._sort_rows` previously derived its categorical sort order from
`df[dim.name].unique()` — i.e. the order categories first appeared in the
*input* frame. Because `_sort_rows` is called from two places that pass
differently-ordered frames (`build()` on the raw input at `data.py:121`, and
`_expand_observ()` on a `space.span()`-merged frame at `data.py:229`), the two
calls could produce different row orderings for the same data. This PR makes
the ordering deterministic by sorting on `dim.grid` (fixed at build time)
instead, adds a regression test, and bumps the package version to `0.2.1`.